### PR TITLE
GridFS API improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
     evaluationDependsOn(':util')
 
     group = 'org.mongodb'
-    version = '1.12.1-SNAPSHOT'
+    version = '1.13.0-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_1_6
     targetCompatibility = JavaVersion.VERSION_1_6
 

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/AsyncInputStream.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/AsyncInputStream.java
@@ -26,7 +26,9 @@ import java.nio.ByteBuffer;
  *
  * <p>See the {@link com.mongodb.async.client.gridfs.helpers} package for adapters that create an {@code AsyncInputStream}</p>
  * @since 1.3
+ * @deprecated replaced by the more idiomatic {@code Publisher<ByteBuffer>} instead
  */
+@Deprecated
 public interface AsyncInputStream {
 
     /**

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/AsyncOutputStream.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/AsyncOutputStream.java
@@ -27,7 +27,9 @@ import java.nio.ByteBuffer;
  *
  * <p>See the {@link com.mongodb.async.client.gridfs.helpers} package for adapters that create an {@code AsyncOutputStream}</p>
  * @since 1.3
+ * @deprecated replaced by the more idiomatic {@code Publisher<ByteBuffer>} instead
  */
+@Deprecated
 public interface AsyncOutputStream {
 
     /**

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
@@ -29,12 +29,15 @@ import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
 
+import java.nio.ByteBuffer;
+
 /**
  * Represents a GridFS Bucket
  *
  * @since 1.3
  */
 @ThreadSafe
+@SuppressWarnings("deprecation")
 public interface GridFSBucket {
 
     /**
@@ -136,7 +139,9 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
      * application will write the contents.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(String filename);
 
     /**
@@ -151,7 +156,9 @@ public interface GridFSBucket {
      * @param options  the GridFSUploadOptions
      * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
      * application will write the contents.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(String filename, GridFSUploadOptions options);
 
     /**
@@ -166,7 +173,9 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
      * application will write the contents.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(BsonValue id, String filename);
 
     /**
@@ -182,7 +191,9 @@ public interface GridFSBucket {
      * @param options  the GridFSUploadOptions
      * @return the GridFSUploadStream that provides the ObjectId for the file to be uploaded and the Stream to which the
      * application will write the contents.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(BsonValue id, String filename, GridFSUploadOptions options);
 
     /**
@@ -199,7 +210,9 @@ public interface GridFSBucket {
      * application will write the contents.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(ClientSession clientSession, String filename);
 
     /**
@@ -217,7 +230,9 @@ public interface GridFSBucket {
      * application will write the contents.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(ClientSession clientSession, String filename, GridFSUploadOptions options);
 
     /**
@@ -235,7 +250,9 @@ public interface GridFSBucket {
      * application will write the contents.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(ClientSession clientSession, BsonValue id, String filename);
 
     /**
@@ -254,7 +271,9 @@ public interface GridFSBucket {
      * application will write the contents.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     GridFSUploadStream openUploadStream(ClientSession clientSession, BsonValue id, String filename, GridFSUploadOptions options);
 
     /**
@@ -267,7 +286,9 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher)} instead
      */
+    @Deprecated
     Publisher<ObjectId> uploadFromStream(String filename, AsyncInputStream source);
 
     /**
@@ -281,7 +302,9 @@ public interface GridFSBucket {
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
      * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     Publisher<ObjectId> uploadFromStream(String filename, AsyncInputStream source, GridFSUploadOptions options);
 
     /**
@@ -295,7 +318,9 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @return a publisher with a single element, representing when the successful upload of the source.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher)} instead
      */
+    @Deprecated
     Publisher<Success> uploadFromStream(BsonValue id, String filename, AsyncInputStream source);
 
     /**
@@ -310,7 +335,9 @@ public interface GridFSBucket {
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
      * @return a publisher with a single element, representing when the successful upload of the source.
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     Publisher<Success> uploadFromStream(BsonValue id, String filename, AsyncInputStream source, GridFSUploadOptions options);
 
     /**
@@ -326,7 +353,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher)} instead
      */
+    @Deprecated
     Publisher<ObjectId> uploadFromStream(ClientSession clientSession, String filename, AsyncInputStream source);
 
     /**
@@ -343,7 +372,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     Publisher<ObjectId> uploadFromStream(ClientSession clientSession, String filename, AsyncInputStream source,
                                          GridFSUploadOptions options);
 
@@ -361,7 +392,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher)} instead
      */
+    @Deprecated
     Publisher<Success> uploadFromStream(ClientSession clientSession, BsonValue id, String filename, AsyncInputStream source);
 
     /**
@@ -379,7 +412,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher, GridFSUploadOptions)} instead
      */
+    @Deprecated
     Publisher<Success> uploadFromStream(ClientSession clientSession, BsonValue id, String filename, AsyncInputStream source,
                                         GridFSUploadOptions options);
 
@@ -388,7 +423,9 @@ public interface GridFSBucket {
      *
      * @param id the ObjectId of the file to be put into a stream.
      * @return the stream
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ObjectId)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(ObjectId id);
 
     /**
@@ -396,7 +433,9 @@ public interface GridFSBucket {
      *
      * @param id the custom id value of the file, to be put into a stream.
      * @return the stream
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(BsonValue)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(BsonValue id);
 
     /**
@@ -405,7 +444,9 @@ public interface GridFSBucket {
      *
      * @param filename the name of the file to be downloaded
      * @return the stream
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(String filename);
 
     /**
@@ -415,7 +456,9 @@ public interface GridFSBucket {
      * @param filename the name of the file to be downloaded
      * @param options  the download options
      * @return the stream
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String, GridFSDownloadOptions)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(String filename, GridFSDownloadOptions options);
 
     /**
@@ -426,7 +469,9 @@ public interface GridFSBucket {
      * @return the stream
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, ObjectId)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, ObjectId id);
 
     /**
@@ -437,7 +482,9 @@ public interface GridFSBucket {
      * @return the stream
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, BsonValue)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, BsonValue id);
 
     /**
@@ -449,7 +496,9 @@ public interface GridFSBucket {
      * @return the stream
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, String filename);
 
     /**
@@ -462,7 +511,9 @@ public interface GridFSBucket {
      * @return the stream
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String, GridFSDownloadOptions)} instead
      */
+    @Deprecated
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, String filename, GridFSDownloadOptions options);
 
     /**
@@ -472,7 +523,9 @@ public interface GridFSBucket {
      * @param id          the ObjectId of the file to be written to the destination stream
      * @param destination the destination stream
      * @return a publisher with a single element, representing the amount of data written
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ObjectId)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(ObjectId id, AsyncOutputStream destination);
 
     /**
@@ -482,7 +535,9 @@ public interface GridFSBucket {
      * @param id          the custom id of the file, to be written to the destination stream
      * @param destination the destination stream
      * @return a publisher with a single element, representing the amount of data written
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(BsonValue)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(BsonValue id, AsyncOutputStream destination);
 
     /**
@@ -492,7 +547,9 @@ public interface GridFSBucket {
      * @param filename    the name of the file to be downloaded
      * @param destination the destination stream
      * @return a publisher with a single element, representing the amount of data written
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(String filename, AsyncOutputStream destination);
 
     /**
@@ -503,7 +560,9 @@ public interface GridFSBucket {
      * @param destination the destination stream
      * @param options     the download options
      * @return a publisher with a single element, representing the amount of data written
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String, GridFSDownloadOptions)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(String filename, AsyncOutputStream destination, GridFSDownloadOptions options);
 
     /**
@@ -516,7 +575,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, ObjectId)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(ClientSession clientSession, ObjectId id, AsyncOutputStream destination);
 
     /**
@@ -529,7 +590,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, BsonValue)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(ClientSession clientSession, BsonValue id, AsyncOutputStream destination);
 
     /**
@@ -542,7 +605,9 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(ClientSession clientSession, String filename, AsyncOutputStream destination);
 
     /**
@@ -556,9 +621,233 @@ public interface GridFSBucket {
      * @return a publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
+     * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String, GridFSDownloadOptions)} instead
      */
+    @Deprecated
     Publisher<Long> downloadToStream(ClientSession clientSession, String filename, AsyncOutputStream destination,
                                      GridFSDownloadOptions options);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @since 1.13
+     */
+    GridFSUploadPublisher<ObjectId> uploadFromPublisher(String filename, Publisher<ByteBuffer> source);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @param options  the GridFSUploadOptions
+     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @since 1.13
+     */
+    GridFSUploadPublisher<ObjectId> uploadFromPublisher(String filename, Publisher<ByteBuffer> source, GridFSUploadOptions options);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param id the custom id value of the file
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @since 1.13
+     */
+    GridFSUploadPublisher<Success> uploadFromPublisher(BsonValue id, String filename, Publisher<ByteBuffer> source);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param id       the custom id value of the file
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @param options  the GridFSUploadOptions
+     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @since 1.13
+     */
+    GridFSUploadPublisher<Success> uploadFromPublisher(BsonValue id, String filename, Publisher<ByteBuffer> source,
+                                                       GridFSUploadOptions options);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSUploadPublisher<ObjectId> uploadFromPublisher(ClientSession clientSession, String filename, Publisher<ByteBuffer> source);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @param options  the GridFSUploadOptions
+     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSUploadPublisher<ObjectId> uploadFromPublisher(ClientSession clientSession, String filename, Publisher<ByteBuffer> source,
+                                                        GridFSUploadOptions options);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param id the custom id value of the file
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSUploadPublisher<Success> uploadFromPublisher(ClientSession clientSession, BsonValue id, String filename, 
+                                                       Publisher<ByteBuffer> source);
+
+    /**
+     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * <p>
+     * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
+     * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
+     * </p>
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param id       the custom id value of the file
+     * @param filename the filename for the stream
+     * @param source   the Stream providing the file data
+     * @param options  the GridFSUploadOptions
+     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSUploadPublisher<Success> uploadFromPublisher(ClientSession clientSession, BsonValue id, String filename, 
+                                                       Publisher<ByteBuffer> source, GridFSUploadOptions options);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
+     * AsyncOutputStream.
+     *
+     * @param id          the ObjectId of the file to be written to the destination stream
+     * @return a publisher with a single element, representing the amount of data written
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(ObjectId id);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
+     * AsyncOutputStream.
+     *
+     * @param id          the custom id of the file, to be written to the destination stream
+     * @return a publisher with a single element, representing the amount of data written
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(BsonValue id);
+
+    /**
+     * Downloads the contents of the latest version of the stored file specified by {@code filename} and writes the contents to
+     * the {@code destination} Stream.
+     *
+     * @param filename    the name of the file to be downloaded
+     * @return a publisher with a single element, representing the amount of data written
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(String filename);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} and writes the
+     * contents to the {@code destination} Stream.
+     *
+     * @param filename    the name of the file to be downloaded
+     * @param options     the download options
+     * @return a publisher with a single element, representing the amount of data written
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(String filename, GridFSDownloadOptions options);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
+     * AsyncOutputStream.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param id          the ObjectId of the file to be written to the destination stream
+     * @return a publisher with a single element, representing the amount of data written
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, ObjectId id);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
+     * AsyncOutputStream.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param id          the custom id of the file, to be written to the destination stream
+     * @return a publisher with a single element, representing the amount of data written
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, BsonValue id);
+
+    /**
+     * Downloads the contents of the latest version of the stored file specified by {@code filename} and writes the contents to
+     * the {@code destination} Stream.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filename    the name of the file to be downloaded
+     * @return a publisher with a single element, representing the amount of data written
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, String filename);
+
+    /**
+     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} and writes the
+     * contents to the {@code destination} Stream.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filename    the name of the file to be downloaded
+     * @param options     the download options
+     * @return a publisher with a single element, representing the amount of data written
+     * @mongodb.server.release 3.6
+     * @since 1.13
+     */
+    GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, String filename, GridFSDownloadOptions options);
 
     /**
      * Finds all documents in the files collection.

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
@@ -439,8 +439,8 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(BsonValue id);
 
     /**
-     * Opens a {@code AsyncInputStream} from which the application can read the contents of the latest version of the stored file specified by the
-     * {@code filename}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the latest version of the stored file specified
+     * by the {@code filename}.
      *
      * @param filename the name of the file to be downloaded
      * @return the stream
@@ -450,8 +450,8 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(String filename);
 
     /**
-     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code filename} and the
-     * revision in {@code options}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code filename}
+     * and the revision in {@code options}.
      *
      * @param filename the name of the file to be downloaded
      * @param options  the download options

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
@@ -285,7 +285,7 @@ public interface GridFSBucket {
      *
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher)} instead
      */
     @Deprecated
@@ -301,7 +301,7 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(String, Publisher, GridFSUploadOptions)} instead
      */
     @Deprecated
@@ -317,7 +317,7 @@ public interface GridFSBucket {
      * @param id the custom id value of the file
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher)} instead
      */
     @Deprecated
@@ -334,7 +334,7 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(BsonValue, String, Publisher, GridFSUploadOptions)} instead
      */
     @Deprecated
@@ -350,7 +350,7 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher)} instead
@@ -369,7 +369,7 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, String, Publisher, GridFSUploadOptions)} instead
@@ -389,7 +389,7 @@ public interface GridFSBucket {
      * @param id the custom id value of the file
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher)} instead
@@ -409,7 +409,7 @@ public interface GridFSBucket {
      * @param filename the filename for the stream
      * @param source   the Stream providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#uploadFromPublisher(ClientSession, BsonValue, String, Publisher, GridFSUploadOptions)} instead
@@ -419,7 +419,7 @@ public interface GridFSBucket {
                                         GridFSUploadOptions options);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code id}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code id}.
      *
      * @param id the ObjectId of the file to be put into a stream.
      * @return the stream
@@ -429,7 +429,7 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(ObjectId id);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code id}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code id}.
      *
      * @param id the custom id value of the file, to be put into a stream.
      * @return the stream
@@ -439,7 +439,7 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(BsonValue id);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the latest version of the stored file specified by the
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the latest version of the stored file specified by the
      * {@code filename}.
      *
      * @param filename the name of the file to be downloaded
@@ -450,7 +450,7 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(String filename);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code filename} and the
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code filename} and the
      * revision in {@code options}.
      *
      * @param filename the name of the file to be downloaded
@@ -462,7 +462,7 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(String filename, GridFSDownloadOptions options);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code id}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code id}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id the ObjectId of the file to be put into a stream.
@@ -475,7 +475,7 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, ObjectId id);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code id}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by {@code id}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id the custom id value of the file, to be put into a stream.
@@ -488,8 +488,8 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, BsonValue id);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the latest version of the stored file specified by the
-     * {@code filename}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the latest version of the stored file
+     * specified by the {@code filename}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename the name of the file to be downloaded
@@ -502,8 +502,8 @@ public interface GridFSBucket {
     GridFSDownloadStream openDownloadStream(ClientSession clientSession, String filename);
 
     /**
-     * Opens a AsyncInputStream from which the application can read the contents of the stored file specified by {@code filename} and the
-     * revision in {@code options}.
+     * Opens a {@code AsyncInputStream} from which the application can read the contents of the stored file specified by
+     * {@code filename} and the revision in {@code options}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename the name of the file to be downloaded
@@ -518,11 +518,11 @@ public interface GridFSBucket {
 
     /**
      * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * {@code AsyncOutputStream}.
      *
      * @param id          the ObjectId of the file to be written to the destination stream
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ObjectId)} instead
      */
     @Deprecated
@@ -530,11 +530,11 @@ public interface GridFSBucket {
 
     /**
      * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * {@code AsyncOutputStream}.
      *
      * @param id          the custom id of the file, to be written to the destination stream
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(BsonValue)} instead
      */
     @Deprecated
@@ -546,7 +546,7 @@ public interface GridFSBucket {
      *
      * @param filename    the name of the file to be downloaded
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String)} instead
      */
     @Deprecated
@@ -559,7 +559,7 @@ public interface GridFSBucket {
      * @param filename    the name of the file to be downloaded
      * @param destination the destination stream
      * @param options     the download options
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(String, GridFSDownloadOptions)} instead
      */
     @Deprecated
@@ -567,12 +567,12 @@ public interface GridFSBucket {
 
     /**
      * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * {@code AsyncOutputStream}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id          the ObjectId of the file to be written to the destination stream
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, ObjectId)} instead
@@ -582,12 +582,12 @@ public interface GridFSBucket {
 
     /**
      * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * {@code AsyncOutputStream}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id          the custom id of the file, to be written to the destination stream
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, BsonValue)} instead
@@ -602,7 +602,7 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param filename    the name of the file to be downloaded
      * @param destination the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String)} instead
@@ -618,7 +618,7 @@ public interface GridFSBucket {
      * @param filename    the name of the file to be downloaded
      * @param destination the destination stream
      * @param options     the download options
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.7
      * @deprecated prefer {@link GridFSBucket#downloadToPublisher(ClientSession, String, GridFSDownloadOptions)} instead
@@ -628,36 +628,36 @@ public interface GridFSBucket {
                                      GridFSDownloadOptions options);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
      * </p>
      *
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @param source   the Publisher providing the file data
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @since 1.13
      */
     GridFSUploadPublisher<ObjectId> uploadFromPublisher(String filename, Publisher<ByteBuffer> source);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
      * </p>
      *
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
+     * @param source   the Publisher providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @since 1.13
      */
     GridFSUploadPublisher<ObjectId> uploadFromPublisher(String filename, Publisher<ByteBuffer> source, GridFSUploadOptions options);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -665,14 +665,14 @@ public interface GridFSBucket {
      *
      * @param id the custom id value of the file
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @param source   the Publisher providing the file data
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @since 1.13
      */
     GridFSUploadPublisher<Success> uploadFromPublisher(BsonValue id, String filename, Publisher<ByteBuffer> source);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -680,16 +680,16 @@ public interface GridFSBucket {
      *
      * @param id       the custom id value of the file
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
+     * @param source   the Publisher providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @since 1.13
      */
     GridFSUploadPublisher<Success> uploadFromPublisher(BsonValue id, String filename, Publisher<ByteBuffer> source,
                                                        GridFSUploadOptions options);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -697,15 +697,15 @@ public interface GridFSBucket {
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @param source   the Publisher providing the file data
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.13
      */
     GridFSUploadPublisher<ObjectId> uploadFromPublisher(ClientSession clientSession, String filename, Publisher<ByteBuffer> source);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -713,9 +713,9 @@ public interface GridFSBucket {
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
+     * @param source   the Publisher providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, the ObjectId of the uploaded file.
+     * @return a Publisher with a single element, the ObjectId of the uploaded file.
      * @mongodb.server.release 3.6
      * @since 1.13
      */
@@ -723,7 +723,7 @@ public interface GridFSBucket {
                                                         GridFSUploadOptions options);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -732,8 +732,8 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param id the custom id value of the file
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @param source   the Publisher providing the file data
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.13
      */
@@ -741,7 +741,7 @@ public interface GridFSBucket {
                                                        Publisher<ByteBuffer> source);
 
     /**
-     * Uploads the contents of the given {@code AsyncInputStream} to a GridFS bucket.
+     * Uploads the contents of the given {@code Publisher} to a GridFS bucket.
      * <p>
      * Reads the contents of the user file from the {@code source} and uploads it as chunks in the chunks collection. After all the
      * chunks have been uploaded, it creates a files collection document for {@code filename} in the files collection.
@@ -750,9 +750,9 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param id       the custom id value of the file
      * @param filename the filename for the stream
-     * @param source   the Stream providing the file data
+     * @param source   the Publisher providing the file data
      * @param options  the GridFSUploadOptions
-     * @return a publisher with a single element, representing when the successful upload of the source.
+     * @return a Publisher with a single element, representing when the successful upload of the source.
      * @mongodb.server.release 3.6
      * @since 1.13
      */
@@ -760,90 +760,84 @@ public interface GridFSBucket {
                                                        Publisher<ByteBuffer> source, GridFSUploadOptions options);
 
     /**
-     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * Downloads the contents of the stored file specified by {@code id} into the {@code Publisher}.
      *
      * @param id          the ObjectId of the file to be written to the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(ObjectId id);
 
     /**
-     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * Downloads the contents of the stored file specified by {@code id} into the {@code Publisher}.
      *
      * @param id          the custom id of the file, to be written to the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(BsonValue id);
 
     /**
-     * Downloads the contents of the latest version of the stored file specified by {@code filename} and writes the contents to
-     * the {@code destination} Stream.
+     * Downloads the contents of the stored file specified by {@code filename} into the {@code Publisher}.
      *
      * @param filename    the name of the file to be downloaded
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(String filename);
 
     /**
-     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} and writes the
-     * contents to the {@code destination} Stream.
+     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} into the
+     * {@code Publisher}.
      *
      * @param filename    the name of the file to be downloaded
      * @param options     the download options
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(String filename, GridFSDownloadOptions options);
 
     /**
-     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * Downloads the contents of the stored file specified by {@code id} into the {@code Publisher}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id          the ObjectId of the file to be written to the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, ObjectId id);
 
     /**
-     * Downloads the contents of the stored file specified by {@code id} and writes the contents to the {@code destination}
-     * AsyncOutputStream.
+     * Downloads the contents of the stored file specified by {@code id} into the {@code Publisher}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param id          the custom id of the file, to be written to the destination stream
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, BsonValue id);
 
     /**
-     * Downloads the contents of the latest version of the stored file specified by {@code filename} and writes the contents to
-     * the {@code destination} Stream.
+     * Downloads the contents of the latest version of the stored file specified by {@code filename} into the {@code Publisher}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename    the name of the file to be downloaded
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.13
      */
     GridFSDownloadPublisher downloadToPublisher(ClientSession clientSession, String filename);
 
     /**
-     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} and writes the
-     * contents to the {@code destination} Stream.
+     * Downloads the contents of the stored file specified by {@code filename} and by the revision in {@code options} into the
+     * {@code Publisher}.
      *
      * @param clientSession the client session with which to associate this operation
      * @param filename    the name of the file to be downloaded
      * @param options     the download options
-     * @return a publisher with a single element, representing the amount of data written
+     * @return a Publisher with a single element, representing the amount of data written
      * @mongodb.server.release 3.6
      * @since 1.13
      */
@@ -907,7 +901,7 @@ public interface GridFSBucket {
      * Given a {@code id}, delete this stored file's files collection document and associated chunks from a GridFS bucket.
      *
      * @param id       the ObjectId of the file to be deleted
-     * @return a publisher with a single element, representing that the file has been deleted
+     * @return a Publisher with a single element, representing that the file has been deleted
      */
     Publisher<Success> delete(ObjectId id);
 
@@ -915,7 +909,7 @@ public interface GridFSBucket {
      * Given a {@code id}, delete this stored file's files collection document and associated chunks from a GridFS bucket.
      *
      * @param id       the ObjectId of the file to be deleted
-     * @return a publisher with a single element, representing that the file has been deleted
+     * @return a Publisher with a single element, representing that the file has been deleted
      */
     Publisher<Success> delete(BsonValue id);
 
@@ -924,7 +918,7 @@ public interface GridFSBucket {
      *
      * @param clientSession the client session with which to associate this operation
      * @param id       the ObjectId of the file to be deleted
-     * @return a publisher with a single element, representing that the file has been deleted
+     * @return a Publisher with a single element, representing that the file has been deleted
      * @mongodb.server.release 3.6
      * @since 1.7
      */
@@ -935,7 +929,7 @@ public interface GridFSBucket {
      *
      * @param clientSession the client session with which to associate this operation
      * @param id       the ObjectId of the file to be deleted
-     * @return a publisher with a single element, representing that the file has been deleted
+     * @return a Publisher with a single element, representing that the file has been deleted
      * @mongodb.server.release 3.6
      * @since 1.7
      */
@@ -946,7 +940,7 @@ public interface GridFSBucket {
      *
      * @param id          the id of the file in the files collection to rename
      * @param newFilename the new filename for the file
-     * @return a publisher with a single element, representing that the file has been renamed
+     * @return a Publisher with a single element, representing that the file has been renamed
      */
     Publisher<Success> rename(ObjectId id, String newFilename);
 
@@ -955,7 +949,7 @@ public interface GridFSBucket {
      *
      * @param id          the id of the file in the files collection to rename
      * @param newFilename the new filename for the file
-     * @return a publisher with a single element, representing that the file has been renamed
+     * @return a Publisher with a single element, representing that the file has been renamed
      */
     Publisher<Success> rename(BsonValue id, String newFilename);
 
@@ -965,7 +959,7 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param id          the id of the file in the files collection to rename
      * @param newFilename the new filename for the file
-     * @return a publisher with a single element, representing that the file has been renamed
+     * @return a Publisher with a single element, representing that the file has been renamed
      * @mongodb.server.release 3.6
      * @since 1.7
      */
@@ -977,7 +971,7 @@ public interface GridFSBucket {
      * @param clientSession the client session with which to associate this operation
      * @param id          the id of the file in the files collection to rename
      * @param newFilename the new filename for the file
-     * @return a publisher with a single element, representing that the file has been renamed
+     * @return a Publisher with a single element, representing that the file has been renamed
      * @mongodb.server.release 3.6
      * @since 1.7
      */
@@ -986,7 +980,7 @@ public interface GridFSBucket {
     /**
      * Drops the data associated with this bucket from the database.
      *
-     * @return a publisher with a single element, representing that the collections have been dropped
+     * @return a Publisher with a single element, representing that the collections have been dropped
      */
     Publisher<Success> drop();
 
@@ -994,7 +988,7 @@ public interface GridFSBucket {
      * Drops the data associated with this bucket from the database.
      *
      * @param clientSession the client session with which to associate this operation
-     * @return a publisher with a single element, representing that the collections have been dropped
+     * @return a Publisher with a single element, representing that the collections have been dropped
      * @mongodb.server.release 3.6
      * @since 1.7
      */

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSDownloadPublisher.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSDownloadPublisher.java
@@ -19,16 +19,16 @@ package com.mongodb.reactivestreams.client.gridfs;
 import com.mongodb.client.gridfs.model.GridFSFile;
 import org.reactivestreams.Publisher;
 
+import java.nio.ByteBuffer;
+
 /**
- * A GridFS InputStream for downloading data from GridFS
+ * A GridFS Publisher for downloading data from GridFS
  *
- * <p>Provides the {@code GridFSFile} for the file to being downloaded as well as the {@code read} methods of a {@link AsyncInputStream}</p>
+ * <p>Provides the {@code GridFSFile} for the file to being downloaded as well as a way to control the batchsize.</p>
  *
- * @since 1.3
- * @deprecated use {@link GridFSDownloadPublisher } instead
+ * @since 1.13
  */
-@Deprecated
-public interface GridFSDownloadStream extends AsyncInputStream {
+public interface GridFSDownloadPublisher extends Publisher<ByteBuffer> {
 
     /**
      * Gets the corresponding {@link GridFSFile} for the file being downloaded
@@ -38,14 +38,16 @@ public interface GridFSDownloadStream extends AsyncInputStream {
     Publisher<GridFSFile> getGridFSFile();
 
     /**
-     * Sets the number of chunks to return per batch.
+     * The preferred number of bytes per ByteBuffer returned by the publisher.
      *
-     * <p>Can be used to control the memory consumption of this InputStream. The smaller the batchSize the lower the memory consumption
+     * <p>Allows for larger than chunk size ByteBuffers. Chunk size is the smallest allowable ByteBuffer size.</p>
+     * <p>Can be used to control the memory consumption of this Publisher. The smaller the bufferSizeBytes the lower the memory consumption
      * and higher latency.</p>
      *
-     * @param batchSize the batch size
+     * <p>Note: Must be set before the publisher is subscribed to.</p>
+     *
+     * @param bufferSizeBytes the preferred buffer size in bytes to use per ByteBuffer in the publisher, defaults to chunk size.
      * @return this
-     * @mongodb.driver.manual reference/method/cursor.batchSize/#cursor.batchSize Batch Size
      */
-    GridFSDownloadStream batchSize(int batchSize);
+    GridFSDownloadPublisher bufferSizeBytes(int bufferSizeBytes);
 }

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSDownloadPublisher.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSDownloadPublisher.java
@@ -33,20 +33,23 @@ public interface GridFSDownloadPublisher extends Publisher<ByteBuffer> {
     /**
      * Gets the corresponding {@link GridFSFile} for the file being downloaded
      *
-     * @return a publisher with a single element, the corresponding GridFSFile for the file being downloaded
+     * @return a Publisher with a single element, the corresponding GridFSFile for the file being downloaded
      */
     Publisher<GridFSFile> getGridFSFile();
 
     /**
-     * The preferred number of bytes per ByteBuffer returned by the publisher.
+     * The preferred number of bytes per {@code ByteBuffer} returned by the {@code Publisher}.
      *
-     * <p>Allows for larger than chunk size ByteBuffers. Chunk size is the smallest allowable ByteBuffer size.</p>
-     * <p>Can be used to control the memory consumption of this Publisher. The smaller the bufferSizeBytes the lower the memory consumption
-     * and higher latency.</p>
+     * <p>Allows for larger than chunk size ByteBuffers. The actual chunk size of the data stored in MongoDB is the smallest allowable 
+     * {@code ByteBuffer} size.</p>
      *
-     * <p>Note: Must be set before the publisher is subscribed to.</p>
+     * <p>Can be used to control the memory consumption of this {@code Publisher}. The smaller the bufferSizeBytes the lower the memory
+     * consumption and higher latency.</p>
      *
-     * @param bufferSizeBytes the preferred buffer size in bytes to use per ByteBuffer in the publisher, defaults to chunk size.
+     * <p>Note: Must be set before the Publisher is subscribed to.</p>
+     *
+     * @param bufferSizeBytes the preferred buffer size in bytes to use per {@code ByteBuffer} in the {@code Publisher}, defaults to chunk
+     *                        size.
      * @return this
      */
     GridFSDownloadPublisher bufferSizeBytes(int bufferSizeBytes);

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
@@ -22,9 +22,9 @@ import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
 
 /**
- * A GridFS publisher for uploading data into GridFS
+ * A GridFS {@code Publisher} for uploading data into GridFS
  *
- * <p>Provides the {@code id} for the file to be uploaded as well as the {@code write} methods of a {@link AsyncOutputStream}</p>
+ * <p>Provides the {@code id} for the file to be uploaded.</p>
  *
  * @param <T> the result type of the publisher
  * @since 1.13

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.reactivestreams.client.gridfs;
 
-import com.mongodb.reactivestreams.client.Success;
 import org.bson.BsonValue;
 import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
@@ -24,12 +23,12 @@ import org.reactivestreams.Publisher;
 /**
  * A GridFS {@code Publisher} for uploading data into GridFS
  *
- * <p>Provides the {@code id} for the file to be uploaded.</p>
+ * <p>Provides the {@code id} for the file to be uploaded. Cancelling the subscription to this publisher will cause any uploaded data
+ * to be cleaned up and removed.</p>
  *
  * @param <T> the result type of the publisher
  * @since 1.13
  */
-
 public interface GridFSUploadPublisher<T> extends Publisher<T> {
 
     /**
@@ -47,12 +46,5 @@ public interface GridFSUploadPublisher<T> extends Publisher<T> {
      * @return the id for this file
      */
     BsonValue getId();
-
-    /**
-     * Aborts the upload and deletes any data.
-     *
-     * @return a publisher with a single element, signifying the abort and cleanup has finished
-     */
-    Publisher<Success> abort();
 
 }

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadPublisher.java
@@ -22,15 +22,15 @@ import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
 
 /**
- * A GridFS OutputStream for uploading data into GridFS
+ * A GridFS publisher for uploading data into GridFS
  *
  * <p>Provides the {@code id} for the file to be uploaded as well as the {@code write} methods of a {@link AsyncOutputStream}</p>
  *
- * @since 1.3
- * @deprecated use {@link GridFSUploadPublisher } instead
+ * @param <T> the result type of the publisher
+ * @since 1.13
  */
-@Deprecated
-public interface GridFSUploadStream extends AsyncOutputStream {
+
+public interface GridFSUploadPublisher<T> extends Publisher<T> {
 
     /**
      * Gets the {@link ObjectId} for the file to be uploaded

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadStream.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSUploadStream.java
@@ -27,7 +27,7 @@ import org.reactivestreams.Publisher;
  * <p>Provides the {@code id} for the file to be uploaded as well as the {@code write} methods of a {@link AsyncOutputStream}</p>
  *
  * @since 1.3
- * @deprecated use {@link GridFSUploadPublisher } instead
+ * @deprecated use {@link GridFSUploadPublisher} instead
  */
 @Deprecated
 public interface GridFSUploadStream extends AsyncOutputStream {
@@ -51,6 +51,8 @@ public interface GridFSUploadStream extends AsyncOutputStream {
     /**
      * Aborts the upload and deletes any data.
      *
+     * <p>Note: With the {@link GridFSUploadPublisher} cancelling the subscription before finishing the upload will abort and cleanup any
+     * uploaded data. </p>
      * @return a publisher with a single element, signifying the abort and cleanup has finished
      */
     Publisher<Success> abort();

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/helpers/AsyncStreamHelper.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/helpers/AsyncStreamHelper.java
@@ -36,8 +36,10 @@ import java.nio.ByteBuffer;
  * </ul>
  *
  * @since 1.3
+ * @deprecated there is no replacement for this class
  */
 @SuppressWarnings("deprecation")
+@Deprecated
 public final class AsyncStreamHelper {
 
     /**

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/helpers/AsyncStreamHelper.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/helpers/AsyncStreamHelper.java
@@ -16,8 +16,6 @@
 
 package com.mongodb.reactivestreams.client.gridfs.helpers;
 
-import com.mongodb.reactivestreams.client.gridfs.AsyncInputStream;
-import com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream;
 import com.mongodb.reactivestreams.client.internal.GridFSAsyncStreamHelper;
 
 import java.io.InputStream;
@@ -26,7 +24,8 @@ import java.nio.ByteBuffer;
 
 
 /**
- * A general helper class that creates {@link AsyncInputStream} or {@link AsyncOutputStream} instances.
+ * A general helper class that creates {@link com.mongodb.reactivestreams.client.gridfs.AsyncInputStream} or
+ * {@link com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream} instances.
  *
  * Provides support for:
  * <ul>
@@ -42,67 +41,67 @@ import java.nio.ByteBuffer;
 public final class AsyncStreamHelper {
 
     /**
-     * Converts a {@code byte[]} into a {@link AsyncInputStream}
+     * Converts a {@code byte[]} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncInputStream}
      *
      * @param srcBytes the data source
      * @return the AsyncInputStream
      */
-    public static AsyncInputStream toAsyncInputStream(final byte[] srcBytes) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncInputStream toAsyncInputStream(final byte[] srcBytes) {
         return GridFSAsyncStreamHelper.toAsyncInputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncInputStream(srcBytes));
     }
 
     /**
-     * Converts a {@code byte[]} into a {@link AsyncOutputStream}
+     * Converts a {@code byte[]} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream}
      *
      * @param dstBytes the data destination
      * @return the AsyncOutputStream
      */
-    public static AsyncOutputStream toAsyncOutputStream(final byte[] dstBytes) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream toAsyncOutputStream(final byte[] dstBytes) {
         return GridFSAsyncStreamHelper.toAsyncOutputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncOutputStream(dstBytes));
     }
 
     /**
-     * Converts a {@link ByteBuffer} into a {@link AsyncInputStream}
+     * Converts a {@link ByteBuffer} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncInputStream}
      *
      * @param srcByteBuffer the data source
      * @return the AsyncInputStream
      */
-    public static AsyncInputStream toAsyncInputStream(final ByteBuffer srcByteBuffer) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncInputStream toAsyncInputStream(final ByteBuffer srcByteBuffer) {
         return GridFSAsyncStreamHelper.toAsyncInputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncInputStream(srcByteBuffer));
     }
 
     /**
-     * Converts a {@link ByteBuffer} into a {@link AsyncOutputStream}
+     * Converts a {@link ByteBuffer} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream}
      *
      * @param dstByteBuffer the data destination
      * @return the AsyncOutputStream
      */
-    public static AsyncOutputStream toAsyncOutputStream(final ByteBuffer dstByteBuffer) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream toAsyncOutputStream(final ByteBuffer dstByteBuffer) {
         return GridFSAsyncStreamHelper.toAsyncOutputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncOutputStream(dstByteBuffer));
     }
 
     /**
-     * Converts a {@link InputStream} into a {@link AsyncInputStream}
+     * Converts a {@link InputStream} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncInputStream}
      *
      * @param inputStream the InputStream
      * @return the AsyncInputStream
      */
-    public static AsyncInputStream toAsyncInputStream(final InputStream inputStream) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncInputStream toAsyncInputStream(final InputStream inputStream) {
         return GridFSAsyncStreamHelper.toAsyncInputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncInputStream(inputStream));
     }
 
     /**
-     * Converts a {@link OutputStream} into a {@link AsyncOutputStream}
+     * Converts a {@link OutputStream} into a {@link com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream}
      *
      * @param outputStream the OutputStream
      * @return the AsyncOutputStream
      */
-    public static AsyncOutputStream toAsyncOutputStream(final OutputStream outputStream) {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream toAsyncOutputStream(final OutputStream outputStream) {
         return GridFSAsyncStreamHelper.toAsyncOutputStream(com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper
                 .toAsyncOutputStream(outputStream));
     }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSAsyncStreamHelper.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSAsyncStreamHelper.java
@@ -18,8 +18,6 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.Block;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.reactivestreams.client.gridfs.AsyncInputStream;
-import com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -45,42 +43,43 @@ public final class GridFSAsyncStreamHelper {
      * @param wrapper the callback AsyncInputStream
      * @return the Publisher AsyncInputStream
      */
-    public static AsyncInputStream toAsyncInputStream(final com.mongodb.async.client.gridfs.AsyncInputStream wrapper) {
-        notNull("wrapper", wrapper);
-        return new AsyncInputStream() {
-            @Override
-            public Publisher<Integer> read(final ByteBuffer dst) {
-                return new SingleResultObservableToPublisher<Integer>(
-                        new Block<com.mongodb.async.SingleResultCallback<Integer>>() {
-                            @Override
-                            public void apply(final com.mongodb.async.SingleResultCallback<Integer> callback) {
-                                wrapper.read(dst, callback);
-                            }
-                        });
-            }
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncInputStream
+        toAsyncInputStream(final com.mongodb.async.client.gridfs.AsyncInputStream wrapper) {
+            notNull("wrapper", wrapper);
+            return new com.mongodb.reactivestreams.client.gridfs.AsyncInputStream() {
+                @Override
+                public Publisher<Integer> read(final ByteBuffer dst) {
+                    return new SingleResultObservableToPublisher<Integer>(
+                            new Block<com.mongodb.async.SingleResultCallback<Integer>>() {
+                                @Override
+                                public void apply(final com.mongodb.async.SingleResultCallback<Integer> callback) {
+                                    wrapper.read(dst, callback);
+                                }
+                            });
+                }
 
-            @Override
-            public Publisher<Long> skip(final long bytesToSkip) {
-                return new SingleResultObservableToPublisher<Long>(
-                        new Block<com.mongodb.async.SingleResultCallback<Long>>() {
-                            @Override
-                            public void apply(final com.mongodb.async.SingleResultCallback<Long> callback) {
-                                wrapper.skip(bytesToSkip, callback);
-                            }
-                        });
-            }
+                @Override
+                public Publisher<Long> skip(final long bytesToSkip) {
+                    return new SingleResultObservableToPublisher<Long>(
+                            new Block<com.mongodb.async.SingleResultCallback<Long>>() {
+                                @Override
+                                public void apply(final com.mongodb.async.SingleResultCallback<Long> callback) {
+                                    wrapper.skip(bytesToSkip, callback);
+                                }
+                            });
+                }
 
-            @Override
-            public Publisher<Success> close() {
-                return new SingleResultObservableToPublisher<Success>(
-                        new Block<com.mongodb.async.SingleResultCallback<Success>>() {
-                            @Override
-                            public void apply(final com.mongodb.async.SingleResultCallback<Success> callback) {
-                                wrapper.close(voidToSuccessCallback(callback));
-                            }
-                        });
-            }
-        };
+                @Override
+                public Publisher<Success> close() {
+                    return new SingleResultObservableToPublisher<Success>(
+                            new Block<com.mongodb.async.SingleResultCallback<Success>>() {
+                                @Override
+                                public void apply(final com.mongodb.async.SingleResultCallback<Success> callback) {
+                                    wrapper.close(voidToSuccessCallback(callback));
+                                }
+                            });
+                }
+            };
     }
 
     /**
@@ -90,175 +89,178 @@ public final class GridFSAsyncStreamHelper {
      * @param wrapper the callback AsyncOutputStream
      * @return the Publisher AsyncOutputStream
      */
-    public static AsyncOutputStream toAsyncOutputStream(final com.mongodb.async.client.gridfs.AsyncOutputStream wrapper) {
-        notNull("wrapper", wrapper);
-        return new AsyncOutputStream() {
+    public static com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream
+        toAsyncOutputStream(final com.mongodb.async.client.gridfs.AsyncOutputStream wrapper) {
+            notNull("wrapper", wrapper);
+            return new com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream() {
 
-            @Override
-            public Publisher<Integer> write(final ByteBuffer src) {
-                return new SingleResultObservableToPublisher<Integer>(
-                        new Block<com.mongodb.async.SingleResultCallback<Integer>>() {
-                            @Override
-                            public void apply(final com.mongodb.async.SingleResultCallback<Integer> callback) {
-                                wrapper.write(src, callback);
-                            }
-                        });
-            }
+                @Override
+                public Publisher<Integer> write(final ByteBuffer src) {
+                    return new SingleResultObservableToPublisher<Integer>(
+                            new Block<com.mongodb.async.SingleResultCallback<Integer>>() {
+                                @Override
+                                public void apply(final com.mongodb.async.SingleResultCallback<Integer> callback) {
+                                    wrapper.write(src, callback);
+                                }
+                            });
+                }
 
-            @Override
-            public Publisher<Success> close() {
-                return new SingleResultObservableToPublisher<Success>(
-                        new Block<com.mongodb.async.SingleResultCallback<Success>>() {
-                            @Override
-                            public void apply(final com.mongodb.async.SingleResultCallback<Success> callback) {
-                                wrapper.close(voidToSuccessCallback(callback));
-                            }
-                        });
-            }
-        };
+                @Override
+                public Publisher<Success> close() {
+                    return new SingleResultObservableToPublisher<Success>(
+                            new Block<com.mongodb.async.SingleResultCallback<Success>>() {
+                                @Override
+                                public void apply(final com.mongodb.async.SingleResultCallback<Success> callback) {
+                                    wrapper.close(voidToSuccessCallback(callback));
+                                }
+                            });
+                }
+            };
     }
 
-    static com.mongodb.async.client.gridfs.AsyncInputStream toCallbackAsyncInputStream(final AsyncInputStream wrapped) {
-        notNull("wrapped", wrapped);
-        return new com.mongodb.async.client.gridfs.AsyncInputStream() {
+    static com.mongodb.async.client.gridfs.AsyncInputStream
+        toCallbackAsyncInputStream(final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream wrapped) {
+            notNull("wrapped", wrapped);
+            return new com.mongodb.async.client.gridfs.AsyncInputStream() {
 
-            @Override
-            public void read(final ByteBuffer dst, final com.mongodb.async.SingleResultCallback<Integer> callback) {
-                wrapped.read(dst).subscribe(new Subscriber<Integer>() {
-                    private Integer result = null;
+                @Override
+                public void read(final ByteBuffer dst, final com.mongodb.async.SingleResultCallback<Integer> callback) {
+                    wrapped.read(dst).subscribe(new Subscriber<Integer>() {
+                        private Integer result = null;
 
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        s.request(1);
-                    }
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
 
-                    @Override
-                    public void onNext(final Integer integer) {
-                        result = integer;
-                    }
+                        @Override
+                        public void onNext(final Integer integer) {
+                            result = integer;
+                        }
 
-                    @Override
-                    public void onError(final Throwable t) {
-                        callback.onResult(null, t);
-                    }
+                        @Override
+                        public void onError(final Throwable t) {
+                            callback.onResult(null, t);
+                        }
 
-                    @Override
-                    public void onComplete() {
-                        callback.onResult(result, null);
-                    }
-                });
-            }
+                        @Override
+                        public void onComplete() {
+                            callback.onResult(result, null);
+                        }
+                    });
+                }
 
-            @Override
-            public void skip(final long bytesToSkip, final com.mongodb.async.SingleResultCallback<Long> callback) {
-                wrapped.skip(bytesToSkip).subscribe(new Subscriber<Long>() {
-                    private Long result = null;
+                @Override
+                public void skip(final long bytesToSkip, final com.mongodb.async.SingleResultCallback<Long> callback) {
+                    wrapped.skip(bytesToSkip).subscribe(new Subscriber<Long>() {
+                        private Long result = null;
 
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        s.request(1);
-                    }
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
 
-                    @Override
-                    public void onNext(final Long skipped) {
-                        result = skipped;
-                    }
+                        @Override
+                        public void onNext(final Long skipped) {
+                            result = skipped;
+                        }
 
-                    @Override
-                    public void onError(final Throwable t) {
-                        callback.onResult(null, t);
-                    }
+                        @Override
+                        public void onError(final Throwable t) {
+                            callback.onResult(null, t);
+                        }
 
-                    @Override
-                    public void onComplete() {
-                        callback.onResult(result, null);
-                    }
-                });
-            }
+                        @Override
+                        public void onComplete() {
+                            callback.onResult(result, null);
+                        }
+                    });
+                }
 
-            @Override
-            public void close(final com.mongodb.async.SingleResultCallback<Void> callback) {
-                wrapped.close().subscribe(new Subscriber<Success>() {
+                @Override
+                public void close(final com.mongodb.async.SingleResultCallback<Void> callback) {
+                    wrapped.close().subscribe(new Subscriber<Success>() {
 
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        s.request(1);
-                    }
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
 
-                    @Override
-                    public void onNext(final Success success) {
-                    }
+                        @Override
+                        public void onNext(final Success success) {
+                        }
 
-                    @Override
-                    public void onError(final Throwable t) {
-                        callback.onResult(null, t);
-                    }
+                        @Override
+                        public void onError(final Throwable t) {
+                            callback.onResult(null, t);
+                        }
 
-                    @Override
-                    public void onComplete() {
-                        callback.onResult(null, null);
-                    }
-                });
-            }
-        };
+                        @Override
+                        public void onComplete() {
+                            callback.onResult(null, null);
+                        }
+                    });
+                }
+            };
     }
 
-    static com.mongodb.async.client.gridfs.AsyncOutputStream toCallbackAsyncOutputStream(final AsyncOutputStream wrapped) {
-        notNull("wrapped", wrapped);
-        return new com.mongodb.async.client.gridfs.AsyncOutputStream() {
+    static com.mongodb.async.client.gridfs.AsyncOutputStream
+        toCallbackAsyncOutputStream(final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream wrapped) {
+            notNull("wrapped", wrapped);
+            return new com.mongodb.async.client.gridfs.AsyncOutputStream() {
 
-            @Override
-            public void write(final ByteBuffer src, final com.mongodb.async.SingleResultCallback<Integer> callback) {
-                wrapped.write(src).subscribe(new Subscriber<Integer>() {
-                    private Integer result = null;
+                @Override
+                public void write(final ByteBuffer src, final com.mongodb.async.SingleResultCallback<Integer> callback) {
+                    wrapped.write(src).subscribe(new Subscriber<Integer>() {
+                        private Integer result = null;
 
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        s.request(1);
-                    }
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
 
-                    @Override
-                    public void onNext(final Integer integer) {
-                        result = integer;
-                    }
+                        @Override
+                        public void onNext(final Integer integer) {
+                            result = integer;
+                        }
 
-                    @Override
-                    public void onError(final Throwable t) {
-                        callback.onResult(null, t);
-                    }
+                        @Override
+                        public void onError(final Throwable t) {
+                            callback.onResult(null, t);
+                        }
 
-                    @Override
-                    public void onComplete() {
-                        callback.onResult(result, null);
-                    }
-                });
-            }
+                        @Override
+                        public void onComplete() {
+                            callback.onResult(result, null);
+                        }
+                    });
+                }
 
-            @Override
-            public void close(final com.mongodb.async.SingleResultCallback<Void> callback) {
-                wrapped.close().subscribe(new Subscriber<Success>() {
+                @Override
+                public void close(final com.mongodb.async.SingleResultCallback<Void> callback) {
+                    wrapped.close().subscribe(new Subscriber<Success>() {
 
-                    @Override
-                    public void onSubscribe(final Subscription s) {
-                        s.request(1);
-                    }
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
 
-                    @Override
-                    public void onNext(final Success success) {
-                    }
+                        @Override
+                        public void onNext(final Success success) {
+                        }
 
-                    @Override
-                    public void onError(final Throwable t) {
-                        callback.onResult(null, t);
-                    }
+                        @Override
+                        public void onError(final Throwable t) {
+                            callback.onResult(null, t);
+                        }
 
-                    @Override
-                    public void onComplete() {
-                        callback.onResult(null, null);
-                    }
-                });
-            }
-        };
+                        @Override
+                        public void onComplete() {
+                            callback.onResult(null, null);
+                        }
+                    });
+                }
+            };
     }
 
     private GridFSAsyncStreamHelper() {

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSBucketImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSBucketImpl.java
@@ -23,17 +23,18 @@ import com.mongodb.WriteConcern;
 import com.mongodb.client.gridfs.model.GridFSDownloadOptions;
 import com.mongodb.client.gridfs.model.GridFSUploadOptions;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.reactivestreams.client.gridfs.AsyncInputStream;
-import com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream;
 import com.mongodb.reactivestreams.client.gridfs.GridFSBucket;
-import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream;
+import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadPublisher;
 import com.mongodb.reactivestreams.client.gridfs.GridFSFindPublisher;
-import com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream;
+import com.mongodb.reactivestreams.client.gridfs.GridFSUploadPublisher;
 import com.mongodb.reactivestreams.client.ClientSession;
+import org.bson.BsonObjectId;
 import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
+
+import java.nio.ByteBuffer;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.reactivestreams.client.internal.GridFSAsyncStreamHelper.toCallbackAsyncInputStream;
@@ -117,54 +118,63 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final String filename) {
         return openUploadStream(filename, new GridFSUploadOptions());
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final String filename, final GridFSUploadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final String filename, final GridFSUploadOptions options) {
         return new GridFSUploadStreamImpl(wrapped.openUploadStream(filename, options));
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final BsonValue id, final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final BsonValue id, final String filename) {
         return openUploadStream(id, filename, new GridFSUploadOptions());
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final BsonValue id, final String filename, final GridFSUploadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final BsonValue id, final String filename, final GridFSUploadOptions options) {
         return new GridFSUploadStreamImpl(wrapped.openUploadStream(id, filename, options));
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final ClientSession clientSession, final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final ClientSession clientSession, final String filename) {
         return openUploadStream(clientSession, filename, new GridFSUploadOptions());
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final ClientSession clientSession, final String filename,
-                                               final GridFSUploadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final ClientSession clientSession, final String filename, final GridFSUploadOptions options) {
         return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession.getWrapped(), filename, options));
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final ClientSession clientSession, final BsonValue id, final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final ClientSession clientSession, final BsonValue id, final String filename) {
         return openUploadStream(clientSession, id, filename, new GridFSUploadOptions());
     }
 
     @Override
-    public GridFSUploadStream openUploadStream(final ClientSession clientSession, final BsonValue id, final String filename,
-                                               final GridFSUploadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream
+    openUploadStream(final ClientSession clientSession, final BsonValue id, final String filename, final GridFSUploadOptions options) {
         return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession.getWrapped(), id, filename, options));
     }
 
     @Override
-    public Publisher<ObjectId> uploadFromStream(final String filename, final AsyncInputStream source) {
+    public Publisher<ObjectId> uploadFromStream(final String filename, 
+                                                final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source) {
         return uploadFromStream(filename, source, new GridFSUploadOptions());
     }
 
     @Override
-    public Publisher<ObjectId> uploadFromStream(final String filename, final AsyncInputStream source, final GridFSUploadOptions options) {
+    public Publisher<ObjectId> uploadFromStream(final String filename, 
+                                                final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source, 
+                                                final GridFSUploadOptions options) {
         return new SingleResultObservableToPublisher<ObjectId>(
                 new Block<com.mongodb.async.SingleResultCallback<ObjectId>>() {
                     @Override
@@ -175,12 +185,14 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public Publisher<Success> uploadFromStream(final BsonValue id, final String filename, final AsyncInputStream source) {
+    public Publisher<Success> uploadFromStream(final BsonValue id, final String filename, 
+                                               final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source) {
         return uploadFromStream(id, filename, source, new GridFSUploadOptions());
     }
 
     @Override
-    public Publisher<Success> uploadFromStream(final BsonValue id, final String filename, final AsyncInputStream source,
+    public Publisher<Success> uploadFromStream(final BsonValue id, final String filename, 
+                                               final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source,
                                                final GridFSUploadOptions options) {
         return new SingleResultObservableToPublisher<Success>(
                 new Block<com.mongodb.async.SingleResultCallback<Success>>() {
@@ -193,12 +205,14 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public Publisher<ObjectId> uploadFromStream(final ClientSession clientSession, final String filename, final AsyncInputStream source) {
+    public Publisher<ObjectId> uploadFromStream(final ClientSession clientSession, final String filename, 
+                                                final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source) {
         return uploadFromStream(clientSession, filename, source, new GridFSUploadOptions());
     }
 
     @Override
-    public Publisher<ObjectId> uploadFromStream(final ClientSession clientSession, final String filename, final AsyncInputStream source,
+    public Publisher<ObjectId> uploadFromStream(final ClientSession clientSession, final String filename, 
+                                                final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source,
                                                 final GridFSUploadOptions options) {
         return new SingleResultObservableToPublisher<ObjectId>(
                 new Block<com.mongodb.async.SingleResultCallback<ObjectId>>() {
@@ -212,13 +226,14 @@ public final class GridFSBucketImpl implements GridFSBucket {
 
     @Override
     public Publisher<Success> uploadFromStream(final ClientSession clientSession, final BsonValue id, final String filename,
-                                               final AsyncInputStream source) {
+                                               final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source) {
         return uploadFromStream(clientSession, id, filename, source, new GridFSUploadOptions());
     }
 
     @Override
     public Publisher<Success> uploadFromStream(final ClientSession clientSession, final BsonValue id, final String filename,
-                                               final AsyncInputStream source, final GridFSUploadOptions options) {
+                                               final com.mongodb.reactivestreams.client.gridfs.AsyncInputStream source, 
+                                               final GridFSUploadOptions options) {
         return new SingleResultObservableToPublisher<Success>(
                 new Block<com.mongodb.async.SingleResultCallback<Success>>() {
                     @Override
@@ -230,48 +245,53 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final ObjectId id) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream openDownloadStream(final ObjectId id) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(id));
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final BsonValue id) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream openDownloadStream(final BsonValue id) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(id));
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream openDownloadStream(final String filename) {
         return openDownloadStream(filename, new GridFSDownloadOptions());
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final String filename, final GridFSDownloadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream 
+    openDownloadStream(final String filename, final GridFSDownloadOptions options) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(filename, options));
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final ObjectId id) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream
+    openDownloadStream(final ClientSession clientSession, final ObjectId id) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), id));
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final BsonValue id) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream 
+    openDownloadStream(final ClientSession clientSession, final BsonValue id) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), id));
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final String filename) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream 
+    openDownloadStream(final ClientSession clientSession, final String filename) {
         return openDownloadStream(clientSession, filename, new GridFSDownloadOptions());
     }
 
     @Override
-    public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final String filename,
-                                                   final GridFSDownloadOptions options) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream 
+    openDownloadStream(final ClientSession clientSession, final String filename, final GridFSDownloadOptions options) {
         return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), filename, options));
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final ObjectId id, final AsyncOutputStream destination) {
+    public Publisher<Long> downloadToStream(final ObjectId id,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
                     @Override
@@ -283,7 +303,8 @@ public final class GridFSBucketImpl implements GridFSBucket {
 
 
     @Override
-    public Publisher<Long> downloadToStream(final BsonValue id, final AsyncOutputStream destination) {
+    public Publisher<Long> downloadToStream(final BsonValue id,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
                     @Override
@@ -294,12 +315,14 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final String filename, final AsyncOutputStream destination) {
+    public Publisher<Long> downloadToStream(final String filename,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return downloadToStream(filename, destination, new GridFSDownloadOptions());
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final String filename, final AsyncOutputStream destination,
+    public Publisher<Long> downloadToStream(final String filename,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination,
                                             final GridFSDownloadOptions options) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
@@ -311,7 +334,8 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final ClientSession clientSession, final ObjectId id, final AsyncOutputStream destination) {
+    public Publisher<Long> downloadToStream(final ClientSession clientSession, final ObjectId id,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
                     @Override
@@ -322,7 +346,8 @@ public final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final ClientSession clientSession, final BsonValue id, final AsyncOutputStream destination) {
+    public Publisher<Long> downloadToStream(final ClientSession clientSession, final BsonValue id,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
                     @Override
@@ -334,12 +359,13 @@ public final class GridFSBucketImpl implements GridFSBucket {
 
     @Override
     public Publisher<Long> downloadToStream(final ClientSession clientSession, final String filename,
-                                            final AsyncOutputStream destination) {
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination) {
         return downloadToStream(clientSession, filename, destination, new GridFSDownloadOptions());
     }
 
     @Override
-    public Publisher<Long> downloadToStream(final ClientSession clientSession, final String filename, final AsyncOutputStream destination,
+    public Publisher<Long> downloadToStream(final ClientSession clientSession, final String filename,
+                                            final com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream destination,
                                             final GridFSDownloadOptions options) {
         return new SingleResultObservableToPublisher<Long>(
                 new Block<com.mongodb.async.SingleResultCallback<Long>>() {
@@ -349,6 +375,106 @@ public final class GridFSBucketImpl implements GridFSBucket {
                                 callback);
                     }
                 });
+    }
+
+    @Override
+    public GridFSUploadPublisher<ObjectId> uploadFromPublisher(final String filename, final Publisher<ByteBuffer> source) {
+        return uploadFromPublisher(filename, source, new GridFSUploadOptions());
+    }
+
+    @Override
+    public GridFSUploadPublisher<ObjectId> uploadFromPublisher(final String filename, final Publisher<ByteBuffer> source,
+                                                   final GridFSUploadOptions options) {
+        return executeUploadFromPublisher(openUploadStream(new BsonObjectId(), filename, options), source).withObjectId();
+    }
+
+    @Override
+    public GridFSUploadPublisher<Success> uploadFromPublisher(final BsonValue id, final String filename,
+                                                              final Publisher<ByteBuffer> source) {
+        return uploadFromPublisher(id, filename, source, new GridFSUploadOptions());
+    }
+
+    @Override
+    public GridFSUploadPublisher<Success> uploadFromPublisher(final BsonValue id, final String filename,
+                                                              final Publisher<ByteBuffer> source, final GridFSUploadOptions options) {
+        return executeUploadFromPublisher(openUploadStream(id, filename, options), source);
+    }
+
+    @Override
+    public GridFSUploadPublisher<ObjectId> uploadFromPublisher(final ClientSession clientSession, final String filename,
+                                                               final Publisher<ByteBuffer> source) {
+        return uploadFromPublisher(clientSession, filename, source, new GridFSUploadOptions());
+    }
+
+    @Override
+    public GridFSUploadPublisher<ObjectId> uploadFromPublisher(final ClientSession clientSession, final String filename,
+                                                               final Publisher<ByteBuffer> source, final GridFSUploadOptions options) {
+        return executeUploadFromPublisher(openUploadStream(clientSession, new BsonObjectId(), filename, options), source)
+                .withObjectId();
+    }
+
+    @Override
+    public GridFSUploadPublisher<Success> uploadFromPublisher(final ClientSession clientSession, final BsonValue id, final String filename,
+                                                              final Publisher<ByteBuffer> source) {
+        return uploadFromPublisher(clientSession, id, filename, source, new GridFSUploadOptions());
+    }
+
+    @Override
+    public GridFSUploadPublisher<Success> uploadFromPublisher(final ClientSession clientSession, final BsonValue id, final String filename,
+                                                              final Publisher<ByteBuffer> source, final GridFSUploadOptions options) {
+        return executeUploadFromPublisher(openUploadStream(clientSession, id, filename, options), source);
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final ObjectId id) {
+        return executeDownloadToPublisher(openDownloadStream(id));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final BsonValue id) {
+        return executeDownloadToPublisher(openDownloadStream(id));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final String filename) {
+        return executeDownloadToPublisher(openDownloadStream(filename));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final String filename, final GridFSDownloadOptions options) {
+        return executeDownloadToPublisher(openDownloadStream(filename, options));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final ClientSession clientSession, final ObjectId id) {
+        return executeDownloadToPublisher(openDownloadStream(clientSession, id));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final ClientSession clientSession, final BsonValue id) {
+        return executeDownloadToPublisher(openDownloadStream(clientSession, id));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final ClientSession clientSession, final String filename) {
+        return executeDownloadToPublisher(openDownloadStream(clientSession, filename));
+    }
+
+    @Override
+    public GridFSDownloadPublisher downloadToPublisher(final ClientSession clientSession, final String filename,
+                                                     final GridFSDownloadOptions options) {
+        return executeDownloadToPublisher(openDownloadStream(clientSession, filename, options));
+    }
+
+    private GridFSDownloadPublisher 
+    executeDownloadToPublisher(final com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream gridFSDownloadStream) {
+        return new GridFSDownloadPublisherImpl(gridFSDownloadStream);
+    }
+
+    private GridFSUploadPublisherImpl
+    executeUploadFromPublisher(final com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream gridFSUploadStream,
+                               final Publisher<ByteBuffer> source) {
+        return new GridFSUploadPublisherImpl(gridFSUploadStream, source);
     }
 
     @Override

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadPublisherImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadPublisherImpl.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.client.gridfs.model.GridFSFile;
+import com.mongodb.reactivestreams.client.Success;
+import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadPublisher;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.nio.ByteBuffer;
+
+@SuppressWarnings("deprecation")
+public class GridFSDownloadPublisherImpl implements GridFSDownloadPublisher {
+    private final com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream gridFSDownloadStream;
+    private int bufferSizeBytes;
+
+    GridFSDownloadPublisherImpl(final com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream gridFSDownloadStream) {
+        this.gridFSDownloadStream = gridFSDownloadStream;
+    }
+
+    @Override
+    public Publisher<GridFSFile> getGridFSFile() {
+        return gridFSDownloadStream.getGridFSFile();
+    }
+
+    @Override
+    public GridFSDownloadPublisher bufferSizeBytes(final int bufferSizeBytes) {
+        this.bufferSizeBytes = bufferSizeBytes;
+        return this;
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super ByteBuffer> s) {
+        s.onSubscribe(new GridFSDownloadSubscription(s));
+    }
+
+    class GridFSDownloadSubscription implements Subscription {
+        private final Subscriber<? super ByteBuffer> outerSubscriber;
+        private final Object lock = new Object();
+
+        /* protected by `lock` */
+        private GridFSFile gridFSFile;
+        private boolean requestedData;
+        private long sizeRead = 0;
+        private long requested = 0;
+        private int currentBatchSize = 0;
+        private boolean isCompleted = false;
+        private boolean isTerminated = false;
+        /* protected by `lock` */
+
+        public GridFSDownloadSubscription(final Subscriber<? super ByteBuffer> outerSubscriber) {
+            this.outerSubscriber = outerSubscriber;
+        }
+
+        private final Subscriber<GridFSFile> gridFSFileSubscriber = new Subscriber<GridFSFile>() {
+            @Override
+            public void onSubscribe(final Subscription s) {
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(final GridFSFile result) {
+                synchronized (lock) {
+                    gridFSFile = result;
+                }
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                outerSubscriber.onError(t);
+                terminate();
+            }
+
+            @Override
+            public void onComplete() {
+                synchronized (lock) {
+                    requestedData = false;
+                }
+                requestMoreOrComplete();
+            }
+        };
+
+        class GridFSDownloadStreamSubscriber implements Subscriber<Integer> {
+            private final ByteBuffer byteBuffer;
+
+            GridFSDownloadStreamSubscriber(final ByteBuffer byteBuffer) {
+                this.byteBuffer = byteBuffer;
+            }
+
+            @Override
+            public void onSubscribe(final Subscription s) {
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(final Integer integer) {
+                synchronized (lock) {
+                    sizeRead += integer;
+                }
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                terminate();
+                outerSubscriber.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                if (byteBuffer.remaining() > 0) {
+                    gridFSDownloadStream.read(byteBuffer).subscribe(new GridFSDownloadStreamSubscriber(byteBuffer));
+                } else {
+                    synchronized (lock) {
+                        requestedData = false;
+                        if (sizeRead == gridFSFile.getLength()) {
+                            isCompleted = true;
+                        }
+                    }
+                    byteBuffer.flip();
+                    outerSubscriber.onNext(byteBuffer);
+                    requestMoreOrComplete();
+                }
+            }
+        }
+
+        @Override
+        public void request(final long n) {
+            synchronized (lock) {
+                requested += n;
+            }
+            requestMoreOrComplete();
+        }
+
+        @Override
+        public void cancel() {
+            terminate();
+        }
+
+        private void requestMoreOrComplete() {
+            synchronized (lock) {
+                if (requested > 0 && !requestedData && !isTerminated && !isCompleted) {
+                    requestedData = true;
+                    if (gridFSFile == null) {
+                        getGridFSFile().subscribe(gridFSFileSubscriber);
+                    } else {
+                        requested--;
+                        int chunkSize = gridFSFile.getChunkSize();
+                        long remaining = gridFSFile.getLength() - sizeRead;
+
+                        if (remaining == 0) {
+                            isCompleted = true;
+                            requestedData = false;
+                            requestMoreOrComplete();
+                        } else {
+                            int byteBufferSize = Math.max(chunkSize, bufferSizeBytes);
+                            byteBufferSize =  Math.min(Long.valueOf(remaining).intValue(), byteBufferSize);
+                            int batchSize = Math.max(byteBufferSize / chunkSize, 1);
+                            ByteBuffer byteBuffer = ByteBuffer.allocate(byteBufferSize);
+                            if (batchSize != currentBatchSize) {
+                                currentBatchSize = batchSize;
+                                gridFSDownloadStream.batchSize(batchSize);
+                            }
+                            gridFSDownloadStream.read(byteBuffer).subscribe(new GridFSDownloadStreamSubscriber(byteBuffer));
+                        }
+                    }
+                } else if (isCompleted && !requestedData && !isTerminated) {
+                    isTerminated = true;
+                    gridFSDownloadStream.close().subscribe(new Subscriber<Success>() {
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(final Success success) {
+                        }
+
+                        @Override
+                        public void onError(final Throwable t) {
+                            outerSubscriber.onError(t);
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            outerSubscriber.onComplete();
+                        }
+                    });
+                }
+            }
+        }
+
+        private void terminate() {
+            synchronized (lock) {
+                isTerminated = true;
+            }
+        }
+    }
+}

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadPublisherImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadPublisherImpl.java
@@ -169,11 +169,11 @@ public class GridFSDownloadPublisherImpl implements GridFSDownloadPublisher {
                         } else {
                             int byteBufferSize = Math.max(chunkSize, bufferSizeBytes);
                             byteBufferSize =  Math.min(Long.valueOf(remaining).intValue(), byteBufferSize);
-                            int batchSize = Math.max(byteBufferSize / chunkSize, 1);
                             ByteBuffer byteBuffer = ByteBuffer.allocate(byteBufferSize);
-                            if (batchSize != currentBatchSize) {
-                                currentBatchSize = batchSize;
-                                gridFSDownloadStream.batchSize(batchSize);
+
+                            if (currentBatchSize == 0) {
+                                currentBatchSize = Math.max(byteBufferSize / chunkSize, 1);
+                                gridFSDownloadStream.batchSize(currentBatchSize);
                             }
                             gridFSDownloadStream.read(byteBuffer).subscribe(new GridFSDownloadStreamSubscriber(byteBuffer));
                         }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadStreamImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSDownloadStreamImpl.java
@@ -19,7 +19,6 @@ package com.mongodb.reactivestreams.client.internal;
 import com.mongodb.Block;
 import com.mongodb.client.gridfs.model.GridFSFile;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream;
 import org.reactivestreams.Publisher;
 
 import java.nio.ByteBuffer;
@@ -29,7 +28,7 @@ import static com.mongodb.reactivestreams.client.internal.PublisherHelper.voidTo
 
 
 @SuppressWarnings("deprecation")
-final class GridFSDownloadStreamImpl implements GridFSDownloadStream {
+final class GridFSDownloadStreamImpl implements com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream {
     private final com.mongodb.async.client.gridfs.GridFSDownloadStream wrapped;
 
     GridFSDownloadStreamImpl(final com.mongodb.async.client.gridfs.GridFSDownloadStream wrapped) {
@@ -48,7 +47,7 @@ final class GridFSDownloadStreamImpl implements GridFSDownloadStream {
     }
 
     @Override
-    public GridFSDownloadStream batchSize(final int batchSize) {
+    public com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream batchSize(final int batchSize) {
         wrapped.batchSize(batchSize);
         return this;
     }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadPublisherImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadPublisherImpl.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.reactivestreams.client.Success;
+import com.mongodb.reactivestreams.client.gridfs.GridFSUploadPublisher;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import java.nio.ByteBuffer;
+
+@SuppressWarnings("deprecation")
+public class GridFSUploadPublisherImpl implements GridFSUploadPublisher<Success> {
+    private final com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream gridFSUploadStream;
+    private final Publisher<ByteBuffer> source;
+
+    GridFSUploadPublisherImpl(final com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream gridFSUploadStream,
+                              final Publisher<ByteBuffer> source) {
+        this.gridFSUploadStream = gridFSUploadStream;
+        this.source = source;
+    }
+
+    @Override
+    public ObjectId getObjectId() {
+        return gridFSUploadStream.getObjectId();
+    }
+
+    @Override
+    public BsonValue getId() {
+        return gridFSUploadStream.getId();
+    }
+
+    @Override
+    public Publisher<Success> abort() {
+        return gridFSUploadStream.abort();
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super Success> s) {
+        s.onSubscribe(new GridFSUploadSubscription(s));
+    }
+
+    class GridFSUploadSubscription implements Subscription {
+        private final Subscriber<? super Success> outerSubscriber;
+        private final Object lock = new Object();
+
+        /* protected by `lock` */
+        private boolean requestedData;
+        private long requested = 0;
+        private boolean isCompleted = false;
+        private boolean isTerminated = false;
+        private boolean subscribed = false;
+        private Subscription sourceSubscription;
+        /* protected by `lock` */
+
+        GridFSUploadSubscription(final Subscriber<? super Success> outerSubscriber) {
+            this.outerSubscriber = outerSubscriber;
+        }
+
+        private final Subscriber<ByteBuffer> sourceSubscriber = new Subscriber<ByteBuffer>() {
+            @Override
+            public void onSubscribe(final Subscription s) {
+                synchronized (lock) {
+                    subscribed = true;
+                    sourceSubscription = s;
+                }
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(final ByteBuffer byteBuffer) {
+                gridFSUploadStream.write(byteBuffer).subscribe(new GridFSUploadStreamSubscriber(byteBuffer));
+            }
+
+            @Override
+            public void onError(final Throwable t) {
+                outerSubscriber.onError(t);
+            }
+
+            @Override
+            public void onComplete() {
+                synchronized (lock) {
+                    isCompleted = true;
+                }
+                requestMoreOrComplete();
+            }
+
+
+            class GridFSUploadStreamSubscriber implements Subscriber<Integer> {
+                private final ByteBuffer byteBuffer;
+
+                GridFSUploadStreamSubscriber(final ByteBuffer byteBuffer) {
+                    this.byteBuffer = byteBuffer;
+                }
+
+                @Override
+                public void onSubscribe(final Subscription s) {
+                    s.request(1);
+                }
+
+                @Override
+                public void onNext(final Integer integer) {
+                }
+
+                @Override
+                public void onError(final Throwable t) {
+                    terminate();
+                    outerSubscriber.onError(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    if (byteBuffer.remaining() > 0) {
+                        sourceSubscriber.onNext(byteBuffer);
+                    } else {
+                        synchronized (lock) {
+                            requestedData = false;
+                        }
+                        requestMoreOrComplete();
+                    }
+                }
+            }
+        };
+
+        @Override
+        public void request(final long n) {
+            synchronized (lock) {
+                requested += n;
+            }
+            requestMoreOrComplete();
+        }
+
+        @Override
+        public void cancel() {
+            terminate();
+            gridFSUploadStream.abort().subscribe(new Subscriber<Success>() {
+                @Override
+                public void onSubscribe(final Subscription s) {
+                    s.request(1);
+                }
+
+                @Override
+                public void onNext(final Success success) {
+                    // Do nothing
+                }
+
+                @Override
+                public void onError(final Throwable t) {
+                    outerSubscriber.onError(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    // Do nothing
+                }
+            });
+        }
+
+        private void requestMoreOrComplete() {
+            synchronized (lock) {
+                if (requested > 0 && !requestedData && !isTerminated && !isCompleted) {
+                    requestedData = true;
+                    requested--;
+                    if (!subscribed) {
+                        source.subscribe(sourceSubscriber);
+                    } else {
+                        sourceSubscription.request(1);
+                    }
+                } else if (isCompleted && !requestedData && !isTerminated) {
+                    isTerminated = true;
+                    gridFSUploadStream.close().subscribe(new Subscriber<Success>() {
+                        @Override
+                        public void onSubscribe(final Subscription s) {
+                            s.request(1);
+                        }
+
+                        @Override
+                        public void onNext(final Success success) {
+                            outerSubscriber.onNext(Success.SUCCESS);
+                        }
+
+                        @Override
+                        public void onError(final Throwable t) {
+                            outerSubscriber.onError(t);
+                        }
+
+                        @Override
+                        public void onComplete() {
+                            outerSubscriber.onComplete();
+                        }
+                    });
+                }
+            }
+        }
+
+        private void terminate() {
+            synchronized (lock) {
+                isTerminated = true;
+            }
+        }
+    }
+
+    GridFSUploadPublisher<ObjectId> withObjectId() {
+        final GridFSUploadPublisherImpl wrapped = this;
+        return new GridFSUploadPublisher<ObjectId>() {
+
+            @Override
+            public ObjectId getObjectId() {
+                return wrapped.getObjectId();
+            }
+
+            @Override
+            public BsonValue getId() {
+                return wrapped.getId();
+            }
+
+            @Override
+            public Publisher<Success> abort() {
+                return wrapped.abort();
+            }
+
+            @Override
+            public void subscribe(final Subscriber<? super ObjectId> objectIdSub) {
+                wrapped.subscribe(new Subscriber<Success>() {
+                    @Override
+                    public void onSubscribe(final Subscription s) {
+                        objectIdSub.onSubscribe(s);
+                    }
+
+                    @Override
+                    public void onNext(final Success success) {
+                        objectIdSub.onNext(getObjectId());
+                    }
+
+                    @Override
+                    public void onError(final Throwable t) {
+                        objectIdSub.onError(t);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        objectIdSub.onComplete();
+                    }
+                });
+            }
+        };
+    }
+}

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadPublisherImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadPublisherImpl.java
@@ -47,11 +47,6 @@ public class GridFSUploadPublisherImpl implements GridFSUploadPublisher<Success>
     }
 
     @Override
-    public Publisher<Success> abort() {
-        return gridFSUploadStream.abort();
-    }
-
-    @Override
     public void subscribe(final Subscriber<? super Success> s) {
         s.onSubscribe(new GridFSUploadSubscription(s));
     }
@@ -261,11 +256,6 @@ public class GridFSUploadPublisherImpl implements GridFSUploadPublisher<Success>
             @Override
             public BsonValue getId() {
                 return wrapped.getId();
-            }
-
-            @Override
-            public Publisher<Success> abort() {
-                return wrapped.abort();
             }
 
             @Override

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadStreamImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSUploadStreamImpl.java
@@ -18,7 +18,6 @@ package com.mongodb.reactivestreams.client.internal;
 
 import com.mongodb.Block;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream;
 import org.bson.BsonValue;
 import org.bson.types.ObjectId;
 import org.reactivestreams.Publisher;
@@ -30,7 +29,7 @@ import static com.mongodb.reactivestreams.client.internal.PublisherHelper.voidTo
 
 
 @SuppressWarnings("deprecation")
-final class GridFSUploadStreamImpl implements GridFSUploadStream {
+final class GridFSUploadStreamImpl implements com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream {
 
     private final com.mongodb.async.client.gridfs.GridFSUploadStream wrapped;
 

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/Fixture.java
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/Fixture.java
@@ -19,7 +19,6 @@ package com.mongodb.reactivestreams.client;
 import com.mongodb.Block;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoCommandException;
-import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.connection.ClusterType;

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/Fixture.java
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/Fixture.java
@@ -16,14 +16,18 @@
 
 package com.mongodb.reactivestreams.client;
 
+import com.mongodb.Block;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerVersion;
+import com.mongodb.reactivestreams.client.internal.ObservableToPublisher;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -38,6 +42,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Helper class for asynchronous tests.
  */
+@SuppressWarnings("deprecation")
 public final class Fixture {
     public static final String DEFAULT_URI = "mongodb://localhost:27017";
     public static final String MONGODB_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
@@ -130,6 +135,16 @@ public final class Fixture {
     public static boolean isReplicaSet() {
         getMongoClient();
         return clusterType == ClusterType.REPLICA_SET;
+    }
+
+    public static <T> Publisher<T> createPublisher(final T... values) {
+        return new ObservableToPublisher<T>(com.mongodb.async.client.Observables.observeAndFlatten(
+                new Block<com.mongodb.async.SingleResultCallback<List<T>>>() {
+                    @Override
+                    public void apply(final com.mongodb.async.SingleResultCallback<List<T>> cb) {
+                        cb.onResult(Arrays.asList(values), null);
+                    }
+                }));
     }
 
     @SuppressWarnings("unchecked")

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
@@ -189,7 +189,7 @@ class GridFSPublisherSpecification extends FunctionalSpecification {
         thrown(MongoGridFSException)
     }
 
-    def 'should round trip with a byteBuffer size of 1024'() {
+    def 'should round trip with a byteBuffer size of 4096'() {
         given:
         def contentSize = 1024 * 1024
         def contentBytes = new byte[contentSize]
@@ -213,10 +213,10 @@ class GridFSPublisherSpecification extends FunctionalSpecification {
         fileInfo.getMetadata() == null
 
         when:
-        def data = runAndCollect(gridFSBucket.downloadToPublisher(fileId).&bufferSizeBytes, 1024)
+        def data = runAndCollect(gridFSBucket.downloadToPublisher(fileId).&bufferSizeBytes, 4096)
 
         then:
-        data.size() == 1024
+        data.size() == 256
         concatByteBuffers(data) == contentBytes
     }
 

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.gridfs
+
+import com.mongodb.MongoGridFSException
+import com.mongodb.client.gridfs.model.GridFSFile
+import com.mongodb.client.gridfs.model.GridFSUploadOptions
+import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.reactivestreams.client.MongoDatabase
+import com.mongodb.reactivestreams.client.FunctionalSpecification
+import org.bson.BsonDocument
+import org.bson.BsonString
+import org.bson.Document
+import org.bson.UuidRepresentation
+import org.bson.codecs.UuidCodec
+import spock.lang.Unroll
+
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.WritableByteChannel
+import java.security.SecureRandom
+
+import static com.mongodb.client.model.Filters.eq
+import static com.mongodb.client.model.Updates.unset
+import static com.mongodb.reactivestreams.client.Fixture.ObservableSubscriber
+import static com.mongodb.reactivestreams.client.Fixture.createPublisher
+import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabaseName
+import static com.mongodb.reactivestreams.client.Fixture.getMongoClient
+import static com.mongodb.reactivestreams.client.MongoClients.getDefaultCodecRegistry
+import static java.util.concurrent.TimeUnit.SECONDS
+import static org.bson.codecs.configuration.CodecRegistries.fromCodecs
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries
+
+class GridFSPublisherSpecification extends FunctionalSpecification {
+    protected MongoDatabase mongoDatabase;
+    protected MongoCollection<GridFSFile> filesCollection;
+    protected MongoCollection<Document> chunksCollection;
+    protected GridFSBucket gridFSBucket;
+    def singleChunkString = 'GridFS'
+    def multiChunkString = singleChunkString.padLeft(1024 * 255 * 5)
+
+    def setup() {
+        mongoDatabase = getMongoClient().getDatabase(getDefaultDatabaseName())
+        filesCollection = mongoDatabase.getCollection('fs.files', GridFSFile)
+        chunksCollection = mongoDatabase.getCollection('fs.chunks')
+        run(filesCollection.&drop)
+        run(chunksCollection.&drop)
+        gridFSBucket = GridFSBuckets.create(mongoDatabase)
+    }
+
+    def cleanup() {
+        if (filesCollection != null) {
+            run(filesCollection.&drop)
+            run(chunksCollection.&drop)
+        }
+    }
+
+    @Unroll
+    def 'should round trip a #description'() {
+        given:
+        def content = multiChunk ? multiChunkString : singleChunkString
+        def contentBytes = content as byte[]
+        def expectedLength = contentBytes.length
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)))
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == chunkCount
+
+        when:
+        def fileInfo = run(gridFSBucket.find().filter(eq('_id', fileId)).&first)
+
+        then:
+        fileInfo.getId().getValue() == fileId
+        fileInfo.getChunkSize() == gridFSBucket.getChunkSizeBytes()
+        fileInfo.getLength() == expectedLength
+        fileInfo.getMetadata() == null
+
+        when:
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+
+        where:
+        description           | multiChunk | chunkCount
+        'a small file'        | false      | 1
+        'a large file'        | true       | 5
+    }
+
+    def 'should round trip with small chunks'() {
+        given:
+        def contentSize = 1024 * 500
+        def chunkSize = 10
+        def contentBytes = new byte[contentSize];
+        new SecureRandom().nextBytes(contentBytes);
+        def options = new GridFSUploadOptions().chunkSizeBytes(chunkSize)
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)), options)
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == contentSize / chunkSize
+
+        when:
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should round trip with data larger than the internal bufferSize'() {
+        given:
+        def contentSize = 1024 * 1024 * 5
+        def chunkSize = 1024 * 1024
+        def contentBytes = new byte[contentSize];
+        new SecureRandom().nextBytes(contentBytes);
+        def options = new GridFSUploadOptions().chunkSizeBytes(chunkSize)
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)), options)
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == contentSize / chunkSize
+
+        when:
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should handle custom ids'() {
+        def contentBytes = multiChunkString.getBytes()
+        def fileId = new BsonString('myFile')
+
+        when:
+        run(gridFSBucket.&uploadFromPublisher, fileId, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)))
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+
+        when:
+        run(gridFSBucket.&rename, fileId, 'newName')
+        data = runAndCollect(gridFSBucket.&downloadToPublisher, 'newName')
+
+        then:
+        concatByteBuffers(data) == contentBytes
+
+        when:
+        run(gridFSBucket.&delete, fileId)
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+        run(chunksCollection.&countDocuments) == 0
+    }
+
+    def 'should throw a chunk not found error when there are no chunks'() {
+        given:
+        def contentSize = 1024 * 1024
+        def contentBytes = new byte[contentSize]
+        new SecureRandom().nextBytes(contentBytes)
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)))
+        run(chunksCollection.&deleteMany, eq('files_id', fileId))
+        run(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        thrown(MongoGridFSException)
+    }
+
+    def 'should round trip with a byteBuffer size of 1024'() {
+        given:
+        def contentSize = 1024 * 1024
+        def contentBytes = new byte[contentSize]
+        new SecureRandom().nextBytes(contentBytes)
+        def options = new GridFSUploadOptions().chunkSizeBytes(1024)
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)), options)
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == 1024
+
+        when:
+        def fileInfo = run(gridFSBucket.find().filter(eq('_id', fileId)).&first)
+
+        then:
+        fileInfo.getObjectId() == fileId
+        fileInfo.getChunkSize() == 1024
+        fileInfo.getLength() == contentSize
+        fileInfo.getMetadata() == null
+
+        when:
+        def data = runAndCollect(gridFSBucket.downloadToPublisher(fileId).&bufferSizeBytes, 1024)
+
+        then:
+        data.size() == 1024
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should use custom uploadOptions when uploading' () {
+        given:
+        def chunkSize = 20
+        def metadata = new Document('archived', false)
+        def options = new GridFSUploadOptions()
+                .chunkSizeBytes(chunkSize)
+                .metadata(metadata)
+        def content = 'qwerty' * 1024
+        def contentBytes = content as byte[]
+        def expectedLength = contentBytes.length as Long
+        def expectedNoChunks = Math.ceil((expectedLength as double) / chunkSize) as int
+
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)), options)
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == expectedNoChunks
+
+        when:
+        def fileInfo = run(gridFSBucket.find().filter(eq('_id', fileId)).&first)
+
+        then:
+        fileInfo.getId().getValue() == fileId
+        fileInfo.getChunkSize() == options.getChunkSizeBytes()
+        fileInfo.getLength() == expectedLength
+        fileInfo.getMetadata() == options.getMetadata()
+
+        when:
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should be able to open by name'() {
+        given:
+        def content = 'Hello GridFS'
+        def contentBytes = content as byte[]
+        def filename = 'myFile'
+        run(gridFSBucket.&uploadFromPublisher, filename, createPublisher(ByteBuffer.wrap(contentBytes)))
+
+
+        when:
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, filename)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should be able to handle missing file'() {
+        when:
+        def filename = 'myFile'
+        run(gridFSBucket.&downloadToPublisher, filename)
+
+        then:
+        thrown(MongoGridFSException)
+    }
+
+    def 'should create the indexes as expected'() {
+        when:
+        def filesIndexKey = Document.parse('{ filename: 1, uploadDate: 1 }')
+        def chunksIndexKey = Document.parse('{ files_id: 1, n: 1 }')
+
+        then:
+        !runAndCollect(filesCollection.&listIndexes)*.get('key').contains(filesIndexKey)
+        !runAndCollect(chunksCollection.&listIndexes)*.get('key').contains(chunksIndexKey)
+
+        when:
+        run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(multiChunkString.getBytes())))
+
+        then:
+        runAndCollect(filesCollection.&listIndexes)*.get('key').contains(Document.parse('{ filename: 1, uploadDate: 1 }'))
+        runAndCollect(chunksCollection.&listIndexes)*.get('key').contains(Document.parse('{ files_id: 1, n: 1 }'))
+    }
+
+    def 'should not create indexes if the files collection is not empty'() {
+        when:
+        run(filesCollection.withDocumentClass(Document).&insertOne, new Document('filename', 'bad file'))
+        def contentBytes = 'Hello GridFS' as byte[]
+
+        then:
+        runAndCollect(filesCollection.&listIndexes).size() == 1
+        runAndCollect(chunksCollection.&listIndexes).size() == 0
+
+        when:
+        run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)))
+
+        then:
+        runAndCollect(filesCollection.&listIndexes).size() == 1
+        runAndCollect(chunksCollection.&listIndexes).size() == 1
+    }
+
+    def 'should use the user provided codec registries for encoding / decoding data'() {
+        given:
+        def codecRegistry = fromRegistries(fromCodecs(new UuidCodec(UuidRepresentation.STANDARD)), getDefaultCodecRegistry())
+        def database = getMongoClient().getDatabase(getDefaultDatabaseName()).withCodecRegistry(codecRegistry)
+        def uuid = UUID.randomUUID()
+        def fileMeta = new Document('uuid', uuid)
+        def gridFSBucket = GridFSBuckets.create(database)
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(multiChunkString.getBytes())),
+                new GridFSUploadOptions().metadata(fileMeta))
+
+        def file = run(gridFSBucket.find(new Document('_id', fileId)).&first)
+
+        then:
+        file.getMetadata() == fileMeta
+
+        when:
+        def fileAsDocument = run(filesCollection.find(BsonDocument).&first)
+
+        then:
+        fileAsDocument.getDocument('metadata').getBinary('uuid').getType() == 4 as byte
+    }
+
+    def 'should handle missing file name data when downloading #description'() {
+        given:
+        def contentBytes = multiChunkString.getBytes()
+
+        when:
+        def fileId = run(gridFSBucket.&uploadFromPublisher, 'myFile', createPublisher(ByteBuffer.wrap(contentBytes)))
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+
+        when:
+        // Remove filename
+        run(filesCollection.&updateOne, eq('_id', fileId), unset('filename'))
+        def data = runAndCollect(gridFSBucket.&downloadToPublisher, fileId)
+
+        then:
+        concatByteBuffers(data) == contentBytes
+    }
+
+    def 'should cleanup when unsubscribing'() {
+        when:
+        def contentBytes = multiChunkString as byte[]
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+
+        when:
+        def subscriber = new ObservableSubscriber()
+        gridFSBucket.uploadFromPublisher('myFile', createPublisher(ByteBuffer.wrap(contentBytes), ByteBuffer.wrap(contentBytes)))
+            .subscribe(subscriber)
+        subscriber.getSubscription().request(1)
+
+        then:
+        !subscriber.isCompleted()
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+        tryMultipleTimes({ run(chunksCollection.&countDocuments) }, 5)
+
+        then:
+        subscriber.getSubscription().cancel()
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+        tryMultipleTimes({ run(chunksCollection.&countDocuments) }, 0)
+    }
+
+    def 'should abort and cleanup'() {
+        when:
+        def contentBytes = multiChunkString as byte[]
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+
+        when:
+        def subscriber = new ObservableSubscriber()
+        def publisher = gridFSBucket.uploadFromPublisher('myFile', createPublisher(ByteBuffer.wrap(contentBytes),
+                ByteBuffer.wrap(contentBytes)))
+        publisher.subscribe(subscriber)
+        subscriber.getSubscription().request(1)
+
+        then:
+        !subscriber.isCompleted()
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+        tryMultipleTimes({ run(chunksCollection.&countDocuments) }, 5)
+
+        then:
+        run(publisher.&abort)
+
+        then:
+        run(filesCollection.&countDocuments) == 0
+        run(chunksCollection.&countDocuments) == 0
+    }
+
+    def tryMultipleTimes(closure, expected) {
+        def counter = 0
+        while (counter < 5) {
+            if (closure.call() == expected) {
+                return true
+            }
+            sleep(500)
+            counter++
+        }
+        assert closure.call() == expected
+    }
+
+    def run(operation, ... args) {
+        def result = runAndCollect(operation, args)
+        result != null ? result.get(0) : result
+    }
+
+    def runAndCollect(operation, ... args) {
+        def subscriber = new ObservableSubscriber()
+        operation.call(args).subscribe(subscriber)
+        subscriber.get(30, SECONDS)
+    }
+
+    byte[] concatByteBuffers(List<ByteBuffer> buffers) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        WritableByteChannel channel = Channels.newChannel(outputStream)
+        for (ByteBuffer buffer: buffers) {
+            channel.write(buffer)
+        }
+        outputStream.close()
+        channel.close()
+        outputStream.toByteArray()
+    }
+}
+

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
@@ -405,35 +405,6 @@ class GridFSPublisherSpecification extends FunctionalSpecification {
         tryMultipleTimes({ run(chunksCollection.&countDocuments) }, 0)
     }
 
-    def 'should abort and cleanup'() {
-        when:
-        def contentBytes = multiChunkString as byte[]
-
-        then:
-        run(filesCollection.&countDocuments) == 0
-
-        when:
-        def subscriber = new ObservableSubscriber()
-        def publisher = gridFSBucket.uploadFromPublisher('myFile', createPublisher(ByteBuffer.wrap(contentBytes),
-                ByteBuffer.wrap(contentBytes)))
-        publisher.subscribe(subscriber)
-        subscriber.getSubscription().request(1)
-
-        then:
-        !subscriber.isCompleted()
-
-        then:
-        run(filesCollection.&countDocuments) == 0
-        tryMultipleTimes({ run(chunksCollection.&countDocuments) }, 5)
-
-        then:
-        run(publisher.&abort)
-
-        then:
-        run(filesCollection.&countDocuments) == 0
-        run(chunksCollection.&countDocuments) == 0
-    }
-
     def tryMultipleTimes(closure, expected) {
         def counter = 0
         while (counter < 5) {

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSTest.java
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSTest.java
@@ -59,8 +59,6 @@ import java.util.List;
 import static com.mongodb.reactivestreams.client.Fixture.ObservableSubscriber;
 import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.reactivestreams.client.Fixture.initializeCollection;
-import static com.mongodb.reactivestreams.client.gridfs.helpers.AsyncStreamHelper.toAsyncInputStream;
-import static com.mongodb.reactivestreams.client.gridfs.helpers.AsyncStreamHelper.toAsyncOutputStream;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -264,7 +262,8 @@ public class GridFSTest extends DatabaseTestCase {
                 }
             } else {
                 ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
-                gridFSBucket.downloadToStream(arguments.getObjectId("id").getValue(), toAsyncOutputStream(outputStream))
+                gridFSBucket.downloadToStream(arguments.getObjectId("id").getValue(),
+                        com.mongodb.reactivestreams.client.gridfs.helpers.AsyncStreamHelper.toAsyncOutputStream(outputStream))
                         .subscribe(subscriber);
                 subscriber.get(30, SECONDS);
             }
@@ -303,7 +302,8 @@ public class GridFSTest extends DatabaseTestCase {
                 }
             } else {
                 ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
-                gridFSBucket.downloadToStream(arguments.getString("filename").getValue(), toAsyncOutputStream(outputStream),
+                gridFSBucket.downloadToStream(arguments.getString("filename").getValue(),
+                        com.mongodb.reactivestreams.client.gridfs.helpers.AsyncStreamHelper.toAsyncOutputStream(outputStream),
                         options).subscribe(subscriber);
                 subscriber.get(30, SECONDS);
             }
@@ -351,7 +351,9 @@ public class GridFSTest extends DatabaseTestCase {
                         })), options).subscribe(subscriber);
             } else {
                 InputStream inputStream = new ByteArrayInputStream(arguments.getBinary("source").getData());
-                gridFSUploadBucket.uploadFromStream(filename, toAsyncInputStream(inputStream), options).subscribe(subscriber);
+                gridFSUploadBucket.uploadFromStream(filename,
+                        com.mongodb.reactivestreams.client.gridfs.helpers.AsyncStreamHelper.toAsyncInputStream(inputStream),
+                        options).subscribe(subscriber);
                 objectId = subscriber.get(30, SECONDS).get(0);
             }
             objectId = subscriber.get(30, SECONDS).get(0);

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSTest.java
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSTest.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.reactivestreams.client.gridfs;
 
+import com.mongodb.Block;
 import com.mongodb.MongoGridFSException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.client.gridfs.model.GridFSDownloadOptions;
@@ -26,6 +27,7 @@ import com.mongodb.reactivestreams.client.DatabaseTestCase;
 import com.mongodb.reactivestreams.client.JsonPoweredTestHelper;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.Success;
+import com.mongodb.reactivestreams.client.internal.ObservableToPublisher;
 import org.bson.BsonArray;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
@@ -47,6 +49,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -63,20 +68,24 @@ import static org.junit.Assert.assertNull;
 
 // See https://github.com/10gen/specifications/tree/master/source/gridfs/tests
 @RunWith(Parameterized.class)
+@SuppressWarnings("deprecation")
 public class GridFSTest extends DatabaseTestCase {
     private final String filename;
     private final String description;
     private final BsonDocument data;
     private final BsonDocument definition;
+    private final boolean publisherApi;
     private MongoCollection<BsonDocument> filesCollection;
     private MongoCollection<BsonDocument> chunksCollection;
     private GridFSBucket gridFSBucket;
 
-    public GridFSTest(final String filename, final String description, final BsonDocument data, final BsonDocument definition) {
+    public GridFSTest(final String filename, final String description, final BsonDocument data, final BsonDocument definition,
+                      final boolean publisherApi) {
         this.filename = filename;
         this.description = description;
         this.data = data;
         this.definition = definition;
+        this.publisherApi = publisherApi;
     }
 
     @Before
@@ -117,7 +126,9 @@ public class GridFSTest extends DatabaseTestCase {
             BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
             for (BsonValue test : testDocument.getArray("tests")) {
                 data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
-                        testDocument.getDocument("data"), test.asDocument()});
+                        testDocument.getDocument("data"), test.asDocument(), false});
+                data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue() + " - Publisher API",
+                        testDocument.getDocument("data"), test.asDocument(), true});
             }
         }
         return data;
@@ -242,12 +253,23 @@ public class GridFSTest extends DatabaseTestCase {
     private void doDownload(final BsonDocument arguments, final BsonDocument assertion) {
         Throwable error = null;
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        WritableByteChannel channel = Channels.newChannel(outputStream);
 
         try {
-            ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
-            gridFSBucket.downloadToStream(arguments.getObjectId("id").getValue(), toAsyncOutputStream(outputStream)).subscribe(subscriber);
-            subscriber.get(30, SECONDS);
+            if (publisherApi) {
+                ObservableSubscriber<ByteBuffer> subscriber = new ObservableSubscriber<ByteBuffer>();
+                gridFSBucket.downloadToPublisher(arguments.getObjectId("id").getValue()).subscribe(subscriber);
+                for (ByteBuffer buffer : subscriber.get(30, SECONDS)) {
+                    channel.write(buffer);
+                }
+            } else {
+                ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
+                gridFSBucket.downloadToStream(arguments.getObjectId("id").getValue(), toAsyncOutputStream(outputStream))
+                        .subscribe(subscriber);
+                subscriber.get(30, SECONDS);
+            }
             outputStream.close();
+            channel.close();
         } catch (Throwable e) {
             error = e;
         }
@@ -264,6 +286,7 @@ public class GridFSTest extends DatabaseTestCase {
     private void doDownloadByName(final BsonDocument arguments, final BsonDocument assertion) {
         Throwable error = null;
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        WritableByteChannel channel = Channels.newChannel(outputStream);
 
         try {
             GridFSDownloadOptions options = new GridFSDownloadOptions();
@@ -272,11 +295,20 @@ public class GridFSTest extends DatabaseTestCase {
                 options.revision(revision);
             }
 
-            ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
-            gridFSBucket.downloadToStream(arguments.getString("filename").getValue(), toAsyncOutputStream(outputStream),
-                    options).subscribe(subscriber);
-            subscriber.get(30, SECONDS);
+            if (publisherApi) {
+                ObservableSubscriber<ByteBuffer> subscriber = new ObservableSubscriber<ByteBuffer>();
+                gridFSBucket.downloadToPublisher(arguments.getString("filename").getValue(), options).subscribe(subscriber);
+                for (ByteBuffer buffer : subscriber.get(30, SECONDS)) {
+                    channel.write(buffer);
+                }
+            } else {
+                ObservableSubscriber<Long> subscriber = new ObservableSubscriber<Long>();
+                gridFSBucket.downloadToStream(arguments.getString("filename").getValue(), toAsyncOutputStream(outputStream),
+                        options).subscribe(subscriber);
+                subscriber.get(30, SECONDS);
+            }
             outputStream.close();
+            channel.close();
         } catch (Throwable e) {
             error = e;
         }
@@ -292,10 +324,9 @@ public class GridFSTest extends DatabaseTestCase {
     private void doUpload(final BsonDocument rawArguments, final BsonDocument assertion) throws Throwable {
         Throwable error = null;
         ObjectId objectId = null;
-        BsonDocument arguments = parseHexDocument(rawArguments, "source");
+        final BsonDocument arguments = parseHexDocument(rawArguments, "source");
         try {
             String filename = arguments.getString("filename").getValue();
-            InputStream inputStream = new ByteArrayInputStream(arguments.getBinary("source").getData());
             GridFSUploadOptions options = new GridFSUploadOptions();
             BsonDocument rawOptions = arguments.getDocument("options", new BsonDocument());
             if (rawOptions.containsKey("chunkSizeBytes")) {
@@ -308,8 +339,21 @@ public class GridFSTest extends DatabaseTestCase {
             if (rawOptions.containsKey("disableMD5")) {
                 gridFSUploadBucket = gridFSUploadBucket.withDisableMD5(rawOptions.getBoolean("disableMD5").getValue());
             }
+
             ObservableSubscriber<ObjectId> subscriber = new ObservableSubscriber<ObjectId>();
-            gridFSUploadBucket.uploadFromStream(filename, toAsyncInputStream(inputStream), options).subscribe(subscriber);
+            if (publisherApi) {
+                gridFSUploadBucket.uploadFromPublisher(filename, new ObservableToPublisher<ByteBuffer>(
+                        com.mongodb.async.client.Observables.observe(new Block<com.mongodb.async.SingleResultCallback<ByteBuffer>>() {
+                            @Override
+                            public void apply(final com.mongodb.async.SingleResultCallback<ByteBuffer> callback) {
+                                callback.onResult(ByteBuffer.wrap(arguments.getBinary("source").getData()), null);
+                            }
+                        })), options).subscribe(subscriber);
+            } else {
+                InputStream inputStream = new ByteArrayInputStream(arguments.getBinary("source").getData());
+                gridFSUploadBucket.uploadFromStream(filename, toAsyncInputStream(inputStream), options).subscribe(subscriber);
+                objectId = subscriber.get(30, SECONDS).get(0);
+            }
             objectId = subscriber.get(30, SECONDS).get(0);
         } catch (Throwable e) {
             error = e;

--- a/driver/src/test/unit/com/mongodb/reactivestreams/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/reactivestreams/client/gridfs/GridFSBucketSpecification.groovy
@@ -25,6 +25,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def wrapped = (WrappedGridFSBucket.methods*.name).sort()
         def local = (GridFSBucket.methods*.name).sort()
+        local.removeAll { it == 'downloadToPublisher' || it == 'uploadFromPublisher' }
 
         expect:
         wrapped == local

--- a/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/GridFSBucketImplSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/GridFSBucketImplSpecification.groovy
@@ -50,6 +50,7 @@ class GridFSBucketImplSpecification extends Specification {
         given:
         def wrapped = (WrappedGridFSBucket.methods*.name).sort()
         def local = (GridFSBucket.methods*.name).sort()
+        local.removeAll { it == 'downloadToPublisher' || it == 'uploadFromPublisher' }
 
         expect:
         wrapped == local


### PR DESCRIPTION
Added upload from a Publisher<ByteBuffer>
Added download to Publisher<ByteBuffer>
Deprecated AsyncInputStream and AsyncOutputStream

JAVA-3440

----

https://evergreen.mongodb.com/version/5dd54aa3e3c33149895e02b5

----

This is relatively complex due to the wrapping nature of the underlying AsyncInput/OutputStream API - so I'll try to annotate the code changes to help readability as much as possible.  The complexities are in `GridFSDownloadPublisherImpl` and `GridFSUploadPublisherImpl`.
