### PR TITLE
GridFS fix source onComplete logic

### DIFF
--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/gridfs/GridFSPublisherSpecification.groovy
@@ -159,6 +159,32 @@ class GridFSPublisherSpecification extends FunctionalSpecification {
                                                       ByteBuffer.wrap(contentBytes)])
     }
 
+    def 'should upload from the source publisher when it contains multiple parts and the total size is smaller than chunksize'() {
+        given:
+        def contentBytes = singleChunkString.getBytes()
+
+        when:
+        def publisher = gridFSBucket.uploadFromPublisher('myFile',
+                createPublisher(ByteBuffer.wrap(contentBytes), ByteBuffer.wrap(contentBytes)))
+
+        def subscriber = new ObservableSubscriber()
+        publisher.subscribe(subscriber)
+        def fileId = subscriber.await(1, 60, SECONDS).getReceived().get(0)
+
+        then:
+        run(filesCollection.&countDocuments) == 1
+        run(chunksCollection.&countDocuments) == 1
+
+        when:
+        subscriber = new ObservableSubscriber()
+        publisher = gridFSBucket.downloadToPublisher(fileId as ObjectId)
+        publisher.subscribe(subscriber)
+        def data = subscriber.await(1, 30, SECONDS).getReceived().get(0)
+
+        then:
+        data.array() == concatByteBuffers([ByteBuffer.wrap(contentBytes), ByteBuffer.wrap(contentBytes)])
+    }
+
     def 'should round trip with data larger than the internal bufferSize'() {
         given:
         def contentSize = 1024 * 1024 * 5


### PR DESCRIPTION
Ensure that onComplete of the source publisher can trigger the completion
steps of the upload publisher

JAVARS-224